### PR TITLE
feature/display_userのリファクタ

### DIFF
--- a/packages/web/src/components/Organisms/Cards/CircleCreateCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/CircleCreateCard.tsx
@@ -7,6 +7,7 @@ import { Input } from "../../Pages/CircleCreatePage";
 import { useSkillAndSubCategoryQuery } from "../../../generated/graphql";
 import SkillCards from "./SkillCards";
 import SubCategoryTags from "../Tags/SubCategoryTags";
+import { selectItems } from "../../../utils/selectItems";
 
 const Card = styled.div`
   padding: 40px;
@@ -128,7 +129,9 @@ const CircleCreateCard: FC<Props> = (props) => {
                 <SkillCards
                   skills={data?.Skill}
                   selectedSkills={props.selectedSkills}
-                  setSkills={props.setSkills}
+                  handleClick={(e) =>
+                    selectItems(e, props.selectedSkills, props.setSkills)
+                  }
                 />
               </StyledGrid>
             ) : (

--- a/packages/web/src/components/Organisms/Cards/SkillCards.tsx
+++ b/packages/web/src/components/Organisms/Cards/SkillCards.tsx
@@ -8,23 +8,12 @@ type Props = {
         __typename?: "Skill" | undefined;
       } & Pick<Skill, "id" | "name" | "avatar">)[]
     | undefined;
-  selectedSkills: number[];
-  setSkills: React.Dispatch<React.SetStateAction<number[]>>;
+  selectedSkills?: number[];
+  handleClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 };
 
 const SkillCards: FC<Props> = (props) => {
-  const { selectedSkills, setSkills } = props;
-  const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    e.preventDefault();
-    let newSelectedSkills: number[];
-    const id = Number(e.currentTarget.id);
-    if (selectedSkills.includes(id)) {
-      newSelectedSkills = selectedSkills.filter((num) => num !== id);
-    } else {
-      newSelectedSkills = [...selectedSkills, id];
-    }
-    setSkills(newSelectedSkills);
-  };
+  const { handleClick, selectedSkills } = props;
 
   const skills = props.skills?.map((skill) => {
     return (

--- a/packages/web/src/components/Organisms/Cards/SkillCards.tsx
+++ b/packages/web/src/components/Organisms/Cards/SkillCards.tsx
@@ -8,8 +8,8 @@ type Props = {
         __typename?: "Skill" | undefined;
       } & Pick<Skill, "id" | "name" | "avatar">)[]
     | undefined;
-  selectedSkills?: number[];
-  setSkills?: React.Dispatch<React.SetStateAction<number[]>>;
+  selectedSkills: number[];
+  setSkills: React.Dispatch<React.SetStateAction<number[]>>;
 };
 
 const SkillCards: FC<Props> = (props) => {
@@ -18,34 +18,30 @@ const SkillCards: FC<Props> = (props) => {
     e.preventDefault();
     let newSelectedSkills: number[];
     const id = Number(e.currentTarget.id);
-    if (selectedSkills && setSkills) {
-      if (selectedSkills.includes(id)) {
-        newSelectedSkills = selectedSkills.filter((num) => num !== id);
-      } else {
-        newSelectedSkills = [...selectedSkills, id];
-      }
-      setSkills(newSelectedSkills);
+    if (selectedSkills.includes(id)) {
+      newSelectedSkills = selectedSkills.filter((num) => num !== id);
+    } else {
+      newSelectedSkills = [...selectedSkills, id];
     }
+    setSkills(newSelectedSkills);
   };
 
-  const skills =
-    props.skills &&
-    props.skills.map((skill) => {
-      return (
-        <SkillCard
-          handleClick={handleClick}
-          id={skill.id.toString()}
-          key={skill.id}
-          name={skill.name}
-          bgColor={
-            selectedSkills && selectedSkills.includes(skill.id)
-              ? "LIGHT_GREEN"
-              : "WHITE"
-          }
-          avatar={skill.avatar}
-        />
-      );
-    });
+  const skills = props.skills?.map((skill) => {
+    return (
+      <SkillCard
+        handleClick={handleClick}
+        id={skill.id.toString()}
+        key={skill.id}
+        name={skill.name}
+        bgColor={
+          selectedSkills && selectedSkills.includes(skill.id)
+            ? "LIGHT_GREEN"
+            : "WHITE"
+        }
+        avatar={skill.avatar}
+      />
+    );
+  });
 
   return <>{skills}</>;
 };

--- a/packages/web/src/components/Organisms/Cards/UserDetailCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/UserDetailCard.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { User, Skill } from "../../../generated/graphql";
 import Avatar from "../../Atoms/Avatar/Default";
 import { COLOR } from "../../../constants/color";
-import SkillCards from "./SkillCards";
+import SkillCard from "../../Molecules/Cards/SkillCard";
 
 type Props = {
   user?: Pick<User, "avatar" | "introduction" | "name" | "interested_in"> & {
@@ -78,7 +78,13 @@ const UserDetailCard: FC<Props> = ({ user }) => {
       <StyledBlock>
         <StyledSubTitle>スキル一覧</StyledSubTitle>
         <StyledGrid height={skillCardHeight || 75}>
-          <SkillCards skills={skills} />
+          {skills?.map((skill) => (
+            <SkillCard
+              name={skill.name}
+              id={skill.id.toString()}
+              avatar={skill.avatar}
+            />
+          ))}
         </StyledGrid>
       </StyledBlock>
     </StyledCard>

--- a/packages/web/src/components/Organisms/Cards/UserDetailCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/UserDetailCard.tsx
@@ -1,12 +1,14 @@
 import React, { FC, useMemo } from "react";
 import styled from "styled-components";
-import { UserQuery } from "../../../generated/graphql";
+import { User, Skill } from "../../../generated/graphql";
 import Avatar from "../../Atoms/Avatar/Default";
 import { COLOR } from "../../../constants/color";
 import SkillCards from "./SkillCards";
 
 type Props = {
-  data: UserQuery;
+  user?: Pick<User, "avatar" | "introduction" | "name" | "interested_in"> & {
+    UserSkills: { Skill: Pick<Skill, "id" | "name" | "avatar"> }[];
+  };
 };
 
 const StyledCard = styled.div`
@@ -48,15 +50,14 @@ const StyledGrid = styled.div<StyleGrid>`
   grid-auto-rows: minmax(${({ height }) => height}px, max-content);
 `;
 
-const UserDetailCard: FC<Props> = ({ data }) => {
+const UserDetailCard: FC<Props> = ({ user }) => {
   const skillCardHeight = useMemo(
-    () => data.user && Math.ceil(data.user?.UserSkills.length / 4) * 75,
-    [data]
+    () => user && Math.ceil(user?.UserSkills.length / 4) * 75,
+    [user]
   );
 
-  if (!data.user) return <p>ユーザーが存在しません</p>;
+  if (!user) return <p>ユーザーが存在しません</p>;
 
-  const user = data.user;
   const skills = user.UserSkills.map((skill) => skill.Skill);
 
   return (

--- a/packages/web/src/components/Organisms/Cards/UserDetailCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/UserDetailCard.tsx
@@ -4,6 +4,7 @@ import { User, Skill } from "../../../generated/graphql";
 import Avatar from "../../Atoms/Avatar/Default";
 import { COLOR } from "../../../constants/color";
 import SkillCard from "../../Molecules/Cards/SkillCard";
+import SkillCards from "./SkillCards";
 
 type Props = {
   user?: Pick<User, "avatar" | "introduction" | "name" | "interested_in"> & {
@@ -78,13 +79,7 @@ const UserDetailCard: FC<Props> = ({ user }) => {
       <StyledBlock>
         <StyledSubTitle>スキル一覧</StyledSubTitle>
         <StyledGrid height={skillCardHeight || 75}>
-          {skills?.map((skill) => (
-            <SkillCard
-              name={skill.name}
-              id={skill.id.toString()}
-              avatar={skill.avatar}
-            />
-          ))}
+          <SkillCards skills={skills} />
         </StyledGrid>
       </StyledBlock>
     </StyledCard>

--- a/packages/web/src/components/Pages/UserDetailPage.tsx
+++ b/packages/web/src/components/Pages/UserDetailPage.tsx
@@ -45,7 +45,7 @@ const UserDetailPage: FC = () => {
 
   return (
     <StyledPage>
-      <UserDetailCard data={data} />
+      <UserDetailCard user={data?.user} />
       <StyledRightButtons>
         {me.id === userId ? (
           <StyledRoundedButton clickHandler={onEditMe} buttonSize="SMALL">

--- a/packages/web/src/utils/selectItems.ts
+++ b/packages/web/src/utils/selectItems.ts
@@ -1,0 +1,15 @@
+export const selectItems = (
+  e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  selectedItems: number[],
+  setSelectedItems: React.Dispatch<React.SetStateAction<number[]>>
+) => {
+  e.preventDefault();
+  let newItems: number[];
+  const id = Number(e.currentTarget.id);
+  if (selectedItems.includes(id)) {
+    newItems = selectedItems.filter((num) => num !== id);
+  } else {
+    newItems = [...selectedItems, id];
+  }
+  setSelectedItems(newItems);
+};


### PR DESCRIPTION
https://github.com/bruno-omars/Hirosaa/pull/22 のレビュー

## UserDetailCardの型
がんばる。

## SkillCards
SkillCardsコンポーネントを，このまま〇〇のパターンは…って増やしていくとコンポーネントの見通しが悪くなりそうなので，[解決策１](https://github.com/bruno-omars/Hirosaa/pull/24/commits/c12b459d8a1f61b32820e8e1b05d43916ec3cf2e)と[解決策２](https://github.com/bruno-omars/Hirosaa/pull/24/commits/ac7441674dc3b2fcb0d5010533bc0b275d4f61d3)を書いてみました。好きな方を選んでください〜〜

### 解決策１
1. ただskillsを渡したらmapして表示してくれるコンポーネント
2. selectedSkills, setSkillsも渡して，選択したのが色つくコンポーネント
を分ける。

2は今のSkillCards。1はコンポーネントにするまでもないかなと思ってベタ書きしてます。

### 解決策２
SkillCardsにはskillsとhandleClickを渡す。(これによって，SkillCardsが限定された使いみちにならなくて済む)。
更に今回のような複数選択のロジックは他にも使うところがありそうなので関数を切り出してしまう。