### PR TITLE
スネークケース→キャメルケース，　単数形にすべきところを単数形に

### DIFF
--- a/packages/hasura/metadata/tables.yaml
+++ b/packages/hasura/metadata/tables.yaml
@@ -49,7 +49,7 @@
   - name: owner
     using:
       foreign_key_constraint_on: owner_id
-  - name: subCategories
+  - name: subCategory
     using:
       foreign_key_constraint_on: sub_category_id
   array_relationships:

--- a/packages/hasura/metadata/tables.yaml
+++ b/packages/hasura/metadata/tables.yaml
@@ -1,45 +1,66 @@
 - table:
     schema: public
     name: circle_skills
+  configuration:
+    custom_root_fields:
+      select: circleSkills
+    custom_column_names:
+      circle_id: circleId
+      skill_id: skillId
   object_relationships:
-  - name: circles
+  - name: circle
     using:
       foreign_key_constraint_on: circle_id
-  - name: skills
+  - name: skill
     using:
       foreign_key_constraint_on: skill_id
 - table:
     schema: public
     name: circle_users
+  configuration:
+    custom_root_fields:
+      select: circleUsers
+    custom_column_names:
+      circle_id: circleId
+      user_id: userId
   object_relationships:
   - name: circle
     using:
       foreign_key_constraint_on: circle_id
-  - name: users
+  - name: user
     using:
       foreign_key_constraint_on: user_id
 - table:
     schema: public
     name: circles
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      what_we_will_do: whatWeWillDo
+      organization_id: organizationId
+      sub_category_id: subCategoryId
+      recruit_title: recruitTitle
+      main_role: mainRole
+      owner_id: ownerId
   object_relationships:
   - name: organizations
     using:
       foreign_key_constraint_on: organization_id
-  - name: sub_categories
-    using:
-      foreign_key_constraint_on: sub_category_id
-  - name: users
+  - name: owner
     using:
       foreign_key_constraint_on: owner_id
+  - name: subCategories
+    using:
+      foreign_key_constraint_on: sub_category_id
   array_relationships:
-  - name: circle_skills
+  - name: circleSkills
     using:
       foreign_key_constraint_on:
         column: circle_id
         table:
           schema: public
           name: circle_skills
-  - name: circle_users
+  - name: circleUsers
     using:
       foreign_key_constraint_on:
         column: circle_id
@@ -100,6 +121,11 @@
 - table:
     schema: public
     name: messages
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      circle_id: circleId
+      user_id: userId
   object_relationships:
   - name: circles
     using:
@@ -128,8 +154,12 @@
 - table:
     schema: public
     name: parent_categories
+  configuration:
+    custom_root_fields:
+      select: parentCategories
+    custom_column_names: {}
   array_relationships:
-  - name: sub_categories
+  - name: subCategories
     using:
       foreign_key_constraint_on:
         column: parent_category_id
@@ -147,14 +177,14 @@
     schema: public
     name: skills
   array_relationships:
-  - name: circle_skills
+  - name: circleSkills
     using:
       foreign_key_constraint_on:
         column: skill_id
         table:
           schema: public
           name: circle_skills
-  - name: user_skills
+  - name: userSkills
     using:
       foreign_key_constraint_on:
         column: skill_id
@@ -172,11 +202,17 @@
 - table:
     schema: public
     name: sub_categories
+  configuration:
+    custom_root_fields:
+      select_by_pk: subCategory
+      select: subCategories
+    custom_column_names:
+      parent_category_id: parentCategoryId
   object_relationships:
-  - name: parent_categories
+  - name: parentCategories
     using:
       foreign_key_constraint_on: parent_category_id
-  - name: sub_categories
+  - name: subCategories
     using:
       manual_configuration:
         remote_table:
@@ -203,16 +239,29 @@
 - table:
     schema: public
     name: user_skills
+  configuration:
+    custom_root_fields:
+      select: userSkills
+    custom_column_names:
+      skill_id: skillId
+      user_id: userId
   object_relationships:
-  - name: skills
+  - name: skill
     using:
       foreign_key_constraint_on: skill_id
-  - name: users
+  - name: user
     using:
       foreign_key_constraint_on: user_id
 - table:
     schema: public
     name: users
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      interested_in: interestedIn
+      last_seen: lastSeen
+      organization_id: organizationId
+      created_at: createdAt
   object_relationships:
   - name: organizations
     using:
@@ -233,7 +282,7 @@
         table:
           schema: public
           name: circles
-  - name: circle_users
+  - name: circleUsers
     using:
       foreign_key_constraint_on:
         column: user_id
@@ -247,7 +296,7 @@
         table:
           schema: public
           name: messages
-  - name: user_skills
+  - name: userSkills
     using:
       foreign_key_constraint_on:
         column: user_id
@@ -270,9 +319,9 @@
         _or:
         - id:
             _eq: X-Hasura-User-Id
-        - circle_users:
+        - circleUsers:
             circle:
-              circle_users:
+              circleUsers:
                 user_id:
                   _eq: X-Hasura-User-Id
   update_permissions:

--- a/packages/web/graphql.schema.json
+++ b/packages/web/graphql.schema.json
@@ -340,23 +340,7 @@
         "description": "columns and relationships of \"circle_skills\"",
         "fields": [
           {
-            "name": "circle_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "circles",
+            "name": "circle",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -365,6 +349,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "circles",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "circleId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -388,23 +388,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "skills",
+            "name": "skill",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -413,6 +397,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "skills",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skillId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -814,7 +814,7 @@
         "description": "aggregate avg on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -838,7 +838,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -872,7 +872,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -892,7 +892,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -951,21 +951,21 @@
             "defaultValue": null
           },
           {
-            "name": "circle_id",
+            "name": "circle",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
+              "name": "circles_bool_exp",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "circles",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "circles_bool_exp",
+              "name": "Int_comparison_exp",
               "ofType": null
             },
             "defaultValue": null
@@ -981,21 +981,21 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skill",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
+              "name": "skills_bool_exp",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "skills",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "skills_bool_exp",
+              "name": "Int_comparison_exp",
               "ofType": null
             },
             "defaultValue": null
@@ -1029,7 +1029,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -1049,7 +1049,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -1070,21 +1070,21 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circle",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
+              "kind": "INPUT_OBJECT",
+              "name": "circles_obj_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "circles",
+            "name": "circleId",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "circles_obj_rel_insert_input",
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null
@@ -1100,21 +1100,21 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skill",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
+              "kind": "INPUT_OBJECT",
+              "name": "skills_obj_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "skills",
+            "name": "skillId",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "skills_obj_rel_insert_input",
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null
@@ -1130,7 +1130,7 @@
         "description": "aggregate max on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -1154,7 +1154,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -1178,7 +1178,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1198,7 +1198,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1218,7 +1218,7 @@
         "description": "aggregate min on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -1242,7 +1242,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -1266,7 +1266,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1286,7 +1286,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1450,21 +1450,21 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circle",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "order_by",
+              "kind": "INPUT_OBJECT",
+              "name": "circles_order_by",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "circles",
+            "name": "circleId",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "circles_order_by",
+              "kind": "ENUM",
+              "name": "order_by",
               "ofType": null
             },
             "defaultValue": null
@@ -1480,21 +1480,21 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skill",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "order_by",
+              "kind": "INPUT_OBJECT",
+              "name": "skills_order_by",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "skills",
+            "name": "skillId",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "skills_order_by",
+              "kind": "ENUM",
+              "name": "order_by",
               "ofType": null
             },
             "defaultValue": null
@@ -1538,7 +1538,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -1550,7 +1550,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -1565,7 +1565,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -1585,7 +1585,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -1605,7 +1605,7 @@
         "description": "aggregate stddev on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -1629,7 +1629,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -1653,7 +1653,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1673,7 +1673,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1693,7 +1693,7 @@
         "description": "aggregate stddev_pop on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -1717,7 +1717,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -1741,7 +1741,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1761,7 +1761,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1781,7 +1781,7 @@
         "description": "aggregate stddev_samp on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -1805,7 +1805,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -1829,7 +1829,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1849,7 +1849,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1869,7 +1869,7 @@
         "description": "aggregate sum on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -1893,7 +1893,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -1917,7 +1917,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1937,7 +1937,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -1960,7 +1960,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -1972,7 +1972,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -1986,7 +1986,7 @@
         "description": "aggregate var_pop on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -2010,7 +2010,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -2034,7 +2034,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -2054,7 +2054,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -2074,7 +2074,7 @@
         "description": "aggregate var_samp on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -2098,7 +2098,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -2122,7 +2122,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -2142,7 +2142,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -2162,7 +2162,7 @@
         "description": "aggregate variance on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -2186,7 +2186,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -2210,7 +2210,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -2230,7 +2230,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -2266,7 +2266,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -2298,23 +2298,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "users",
+            "name": "user",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -2323,6 +2307,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "users",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -2724,7 +2724,7 @@
         "description": "aggregate avg on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -2760,7 +2760,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -2839,7 +2839,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -2859,21 +2859,21 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "user",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
+              "name": "users_bool_exp",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "users",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "users_bool_exp",
+              "name": "String_comparison_exp",
               "ofType": null
             },
             "defaultValue": null
@@ -2907,7 +2907,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -2948,7 +2948,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -2968,21 +2968,21 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "user",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
+              "kind": "INPUT_OBJECT",
+              "name": "users_obj_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "users",
+            "name": "userId",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "users_obj_rel_insert_input",
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
@@ -2998,7 +2998,7 @@
         "description": "aggregate max on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3022,7 +3022,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "args": [],
             "type": {
@@ -3046,7 +3046,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3066,7 +3066,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3086,7 +3086,7 @@
         "description": "aggregate min on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3110,7 +3110,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "args": [],
             "type": {
@@ -3134,7 +3134,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3154,7 +3154,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3328,7 +3328,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3348,21 +3348,21 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "user",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "order_by",
+              "kind": "INPUT_OBJECT",
+              "name": "users_order_by",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "users",
+            "name": "userId",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "users_order_by",
+              "kind": "ENUM",
+              "name": "order_by",
               "ofType": null
             },
             "defaultValue": null
@@ -3406,7 +3406,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -3418,7 +3418,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -3433,7 +3433,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -3453,7 +3453,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -3473,7 +3473,7 @@
         "description": "aggregate stddev on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3509,7 +3509,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3539,7 +3539,7 @@
         "description": "aggregate stddev_pop on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3575,7 +3575,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3605,7 +3605,7 @@
         "description": "aggregate stddev_samp on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3641,7 +3641,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3671,7 +3671,7 @@
         "description": "aggregate sum on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3707,7 +3707,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3740,7 +3740,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -3752,7 +3752,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -3766,7 +3766,7 @@
         "description": "aggregate var_pop on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3802,7 +3802,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3832,7 +3832,7 @@
         "description": "aggregate var_samp on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3868,7 +3868,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3898,7 +3898,7 @@
         "description": "aggregate variance on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -3934,7 +3934,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -3980,7 +3980,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_skills",
+            "name": "circleSkills",
             "description": "An array relationship",
             "args": [
               {
@@ -4071,7 +4071,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_skills_aggregate",
+            "name": "circleSkills_aggregate",
             "description": "An aggregated array relationship",
             "args": [
               {
@@ -4154,7 +4154,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_users",
+            "name": "circleUsers",
             "description": "An array relationship",
             "args": [
               {
@@ -4245,7 +4245,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_users_aggregate",
+            "name": "circleUsers_aggregate",
             "description": "An aggregated array relationship",
             "args": [
               {
@@ -4344,7 +4344,7 @@
             "deprecationReason": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "args": [],
             "type": {
@@ -4546,7 +4546,7 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "args": [],
             "type": {
@@ -4570,55 +4570,7 @@
             "deprecationReason": null
           },
           {
-            "name": "owner_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "recruit_title",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sub_categories",
-            "description": "An object relationship",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "sub_categories",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sub_category_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "users",
+            "name": "owner",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -4630,7 +4582,55 @@
             "deprecationReason": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "ownerId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recruitTitle",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subCategories",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sub_categories",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subCategoryId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "whatWeWillDo",
             "description": null,
             "args": [],
             "type": {
@@ -5048,7 +5048,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -5082,7 +5082,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5151,7 +5151,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_skills",
+            "name": "circleSkills",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5161,7 +5161,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_users",
+            "name": "circleUsers",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5181,7 +5181,7 @@
             "defaultValue": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5211,7 +5211,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5231,47 +5231,7 @@
             "defaultValue": null
           },
           {
-            "name": "owner_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "recruit_title",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "sub_categories",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "sub_categories_bool_exp",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "sub_category_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "users",
+            "name": "owner",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5281,7 +5241,47 @@
             "defaultValue": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "ownerId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "recruitTitle",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "subCategories",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sub_categories_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "subCategoryId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "whatWeWillDo",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5329,7 +5329,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -5360,7 +5360,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_skills",
+            "name": "circleSkills",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5370,7 +5370,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_users",
+            "name": "circleUsers",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5390,7 +5390,7 @@
             "defaultValue": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -5420,7 +5420,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -5440,47 +5440,7 @@
             "defaultValue": null
           },
           {
-            "name": "owner_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "recruit_title",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "sub_categories",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "sub_categories_obj_rel_insert_input",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "sub_category_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "users",
+            "name": "owner",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5490,7 +5450,47 @@
             "defaultValue": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "ownerId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "recruitTitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "subCategories",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sub_categories_obj_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "subCategoryId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "whatWeWillDo",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -5534,7 +5534,7 @@
             "deprecationReason": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "args": [],
             "type": {
@@ -5558,7 +5558,7 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "args": [],
             "type": {
@@ -5570,7 +5570,7 @@
             "deprecationReason": null
           },
           {
-            "name": "owner_id",
+            "name": "ownerId",
             "description": null,
             "args": [],
             "type": {
@@ -5582,7 +5582,7 @@
             "deprecationReason": null
           },
           {
-            "name": "recruit_title",
+            "name": "recruitTitle",
             "description": null,
             "args": [],
             "type": {
@@ -5594,7 +5594,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -5606,7 +5606,7 @@
             "deprecationReason": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "whatWeWillDo",
             "description": null,
             "args": [],
             "type": {
@@ -5650,7 +5650,7 @@
             "defaultValue": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5670,7 +5670,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5680,7 +5680,7 @@
             "defaultValue": null
           },
           {
-            "name": "owner_id",
+            "name": "ownerId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5690,7 +5690,7 @@
             "defaultValue": null
           },
           {
-            "name": "recruit_title",
+            "name": "recruitTitle",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5700,7 +5700,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5710,7 +5710,7 @@
             "defaultValue": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "whatWeWillDo",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5754,7 +5754,7 @@
             "deprecationReason": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "args": [],
             "type": {
@@ -5778,7 +5778,7 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "args": [],
             "type": {
@@ -5790,7 +5790,7 @@
             "deprecationReason": null
           },
           {
-            "name": "owner_id",
+            "name": "ownerId",
             "description": null,
             "args": [],
             "type": {
@@ -5802,7 +5802,7 @@
             "deprecationReason": null
           },
           {
-            "name": "recruit_title",
+            "name": "recruitTitle",
             "description": null,
             "args": [],
             "type": {
@@ -5814,7 +5814,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -5826,7 +5826,7 @@
             "deprecationReason": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "whatWeWillDo",
             "description": null,
             "args": [],
             "type": {
@@ -5870,7 +5870,7 @@
             "defaultValue": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5890,7 +5890,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5900,7 +5900,7 @@
             "defaultValue": null
           },
           {
-            "name": "owner_id",
+            "name": "ownerId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5910,7 +5910,7 @@
             "defaultValue": null
           },
           {
-            "name": "recruit_title",
+            "name": "recruitTitle",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5920,7 +5920,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -5930,7 +5930,7 @@
             "defaultValue": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "whatWeWillDo",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6104,7 +6104,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_skills_aggregate",
+            "name": "circleSkills_aggregate",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -6114,7 +6114,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_users_aggregate",
+            "name": "circleUsers_aggregate",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -6134,7 +6134,7 @@
             "defaultValue": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6164,7 +6164,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6184,47 +6184,7 @@
             "defaultValue": null
           },
           {
-            "name": "owner_id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "recruit_title",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "sub_categories",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "sub_categories_order_by",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "sub_category_id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "users",
+            "name": "owner",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -6234,7 +6194,47 @@
             "defaultValue": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "ownerId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "recruitTitle",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "subCategories",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "sub_categories_order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "subCategoryId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "whatWeWillDo",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6294,7 +6294,7 @@
             "deprecationReason": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -6306,31 +6306,31 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "owner_id",
+            "name": "ownerId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "recruit_title",
+            "name": "recruitTitle",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "whatWeWillDo",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -6365,7 +6365,7 @@
             "defaultValue": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6385,7 +6385,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6395,7 +6395,7 @@
             "defaultValue": null
           },
           {
-            "name": "owner_id",
+            "name": "ownerId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6405,7 +6405,7 @@
             "defaultValue": null
           },
           {
-            "name": "recruit_title",
+            "name": "recruitTitle",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6415,7 +6415,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6425,7 +6425,7 @@
             "defaultValue": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "whatWeWillDo",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6457,7 +6457,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -6491,7 +6491,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6523,7 +6523,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -6557,7 +6557,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6589,7 +6589,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -6623,7 +6623,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6655,7 +6655,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -6689,7 +6689,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6724,7 +6724,7 @@
             "deprecationReason": null
           },
           {
-            "name": "main_role",
+            "name": "mainRole",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -6736,31 +6736,31 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "owner_id",
+            "name": "ownerId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "recruit_title",
+            "name": "recruitTitle",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "what_we_will_do",
+            "name": "whatWeWillDo",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -6786,7 +6786,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -6820,7 +6820,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6852,7 +6852,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -6886,7 +6886,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6918,7 +6918,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -6952,7 +6952,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_category_id",
+            "name": "subCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -6972,7 +6972,7 @@
         "description": "columns and relationships of \"messages\"",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -7052,7 +7052,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "args": [],
             "type": {
@@ -7478,7 +7478,7 @@
         "description": "aggregate avg on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -7514,7 +7514,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -7583,7 +7583,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -7633,7 +7633,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -7681,7 +7681,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -7712,7 +7712,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -7762,7 +7762,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -7792,7 +7792,7 @@
         "description": "aggregate max on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -7840,7 +7840,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "args": [],
             "type": {
@@ -7864,7 +7864,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -7904,7 +7904,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -7924,7 +7924,7 @@
         "description": "aggregate min on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -7972,7 +7972,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "args": [],
             "type": {
@@ -7996,7 +7996,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8036,7 +8036,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8200,7 +8200,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8250,7 +8250,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8308,7 +8308,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -8332,7 +8332,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -8347,7 +8347,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -8387,7 +8387,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -8407,7 +8407,7 @@
         "description": "aggregate stddev on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -8443,7 +8443,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8473,7 +8473,7 @@
         "description": "aggregate stddev_pop on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -8509,7 +8509,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8539,7 +8539,7 @@
         "description": "aggregate stddev_samp on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -8575,7 +8575,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8605,7 +8605,7 @@
         "description": "aggregate sum on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -8641,7 +8641,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8674,7 +8674,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -8698,7 +8698,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -8712,7 +8712,7 @@
         "description": "aggregate var_pop on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -8748,7 +8748,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8778,7 +8778,7 @@
         "description": "aggregate var_samp on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -8814,7 +8814,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -8844,7 +8844,7 @@
         "description": "aggregate variance on columns",
         "fields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "args": [],
             "type": {
@@ -8880,7 +8880,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "circle_id",
+            "name": "circleId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -12443,7 +12443,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": "An array relationship",
             "args": [
               {
@@ -12534,7 +12534,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_categories_aggregate",
+            "name": "subCategories_aggregate",
             "description": "An aggregated array relationship",
             "args": [
               {
@@ -13114,7 +13114,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -13193,7 +13193,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -13509,7 +13509,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_categories_aggregate",
+            "name": "subCategories_aggregate",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -13939,7 +13939,7 @@
         "description": "query root",
         "fields": [
           {
-            "name": "circle_skills",
+            "name": "circleSkills",
             "description": "fetch data from the table: \"circle_skills\"",
             "args": [
               {
@@ -14021,6 +14021,97 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "circle_skills",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "circleUsers",
+            "description": "fetch data from the table: \"circle_users\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "circle_users_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "circle_users_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "circle_users_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "circle_users",
                     "ofType": null
                   }
                 }
@@ -14135,97 +14226,6 @@
               "kind": "OBJECT",
               "name": "circle_skills",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "circle_users",
-            "description": "fetch data from the table: \"circle_users\"",
-            "args": [
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "circle_users_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "circle_users_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "circle_users_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "circle_users",
-                    "ofType": null
-                  }
-                }
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14944,7 +14944,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_categories",
+            "name": "parentCategories",
             "description": "fetch data from the table: \"parent_categories\"",
             "args": [
               {
@@ -15346,7 +15346,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": "fetch data from the table: \"sub_categories\"",
             "args": [
               {
@@ -15437,6 +15437,33 @@
             "deprecationReason": null
           },
           {
+            "name": "subCategory",
+            "description": "fetch data from the table: \"sub_categories\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sub_categories",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sub_categories_aggregate",
             "description": "fetch aggregated fields from the table: \"sub_categories\"",
             "args": [
@@ -15520,34 +15547,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_categories_by_pk",
-            "description": "fetch data from the table: \"sub_categories\" using primary key columns",
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "sub_categories",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "user_skills",
+            "name": "userSkills",
             "description": "fetch data from the table: \"user_skills\"",
             "args": [
               {
@@ -15976,7 +15976,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_skills",
+            "name": "circleSkills",
             "description": "An array relationship",
             "args": [
               {
@@ -16067,7 +16067,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_skills_aggregate",
+            "name": "circleSkills_aggregate",
             "description": "An aggregated array relationship",
             "args": [
               {
@@ -16182,7 +16182,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_skills",
+            "name": "userSkills",
             "description": "An array relationship",
             "args": [
               {
@@ -16273,7 +16273,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_skills_aggregate",
+            "name": "userSkills_aggregate",
             "description": "An aggregated array relationship",
             "args": [
               {
@@ -16843,7 +16843,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_skills",
+            "name": "circleSkills",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -16873,7 +16873,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_skills",
+            "name": "userSkills",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -16942,7 +16942,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_skills",
+            "name": "circleSkills",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -16972,7 +16972,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_skills",
+            "name": "userSkills",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -17322,7 +17322,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_skills_aggregate",
+            "name": "circleSkills_aggregate",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -17352,7 +17352,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_skills_aggregate",
+            "name": "userSkills_aggregate",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -18010,7 +18010,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_categories",
+            "name": "parentCategories",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -18026,7 +18026,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -18042,7 +18042,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -18460,7 +18460,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -18494,7 +18494,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -18583,7 +18583,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_categories",
+            "name": "parentCategories",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -18593,7 +18593,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -18603,7 +18603,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -18651,7 +18651,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -18702,7 +18702,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_categories",
+            "name": "parentCategories",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -18712,7 +18712,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -18722,7 +18722,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -18766,7 +18766,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -18810,7 +18810,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -18854,7 +18854,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -18898,7 +18898,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19092,7 +19092,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_categories",
+            "name": "parentCategories",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -19102,7 +19102,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19112,7 +19112,7 @@
             "defaultValue": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -19172,7 +19172,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -19207,7 +19207,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -19239,7 +19239,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -19273,7 +19273,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19305,7 +19305,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -19339,7 +19339,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19371,7 +19371,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -19405,7 +19405,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19437,7 +19437,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -19471,7 +19471,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19506,7 +19506,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -19532,7 +19532,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -19566,7 +19566,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19598,7 +19598,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -19632,7 +19632,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19664,7 +19664,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "args": [],
             "type": {
@@ -19698,7 +19698,7 @@
             "defaultValue": null
           },
           {
-            "name": "parent_category_id",
+            "name": "parentCategoryId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -19718,7 +19718,7 @@
         "description": "subscription root",
         "fields": [
           {
-            "name": "circle_skills",
+            "name": "circleSkills",
             "description": "fetch data from the table: \"circle_skills\"",
             "args": [
               {
@@ -19800,6 +19800,97 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "circle_skills",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "circleUsers",
+            "description": "fetch data from the table: \"circle_users\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "circle_users_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "circle_users_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "circle_users_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "circle_users",
                     "ofType": null
                   }
                 }
@@ -19914,97 +20005,6 @@
               "kind": "OBJECT",
               "name": "circle_skills",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "circle_users",
-            "description": "fetch data from the table: \"circle_users\"",
-            "args": [
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "circle_users_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "circle_users_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "circle_users_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "circle_users",
-                    "ofType": null
-                  }
-                }
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -20723,7 +20723,7 @@
             "deprecationReason": null
           },
           {
-            "name": "parent_categories",
+            "name": "parentCategories",
             "description": "fetch data from the table: \"parent_categories\"",
             "args": [
               {
@@ -21125,7 +21125,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_categories",
+            "name": "subCategories",
             "description": "fetch data from the table: \"sub_categories\"",
             "args": [
               {
@@ -21216,6 +21216,33 @@
             "deprecationReason": null
           },
           {
+            "name": "subCategory",
+            "description": "fetch data from the table: \"sub_categories\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "sub_categories",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sub_categories_aggregate",
             "description": "fetch aggregated fields from the table: \"sub_categories\"",
             "args": [
@@ -21299,34 +21326,7 @@
             "deprecationReason": null
           },
           {
-            "name": "sub_categories_by_pk",
-            "description": "fetch data from the table: \"sub_categories\" using primary key columns",
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "sub_categories",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "user_skills",
+            "name": "userSkills",
             "description": "fetch data from the table: \"user_skills\"",
             "args": [
               {
@@ -21898,23 +21898,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "skills",
+            "name": "skill",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -21930,7 +21914,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -21938,7 +21922,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -21946,7 +21930,7 @@
             "deprecationReason": null
           },
           {
-            "name": "users",
+            "name": "user",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -21955,6 +21939,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "users",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -22380,7 +22380,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -22424,7 +22424,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -22503,17 +22503,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Int_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "skills",
+            "name": "skill",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -22523,21 +22513,31 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
+              "name": "Int_comparison_exp",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "users",
+            "name": "user",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "users_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
               "ofType": null
             },
             "defaultValue": null
@@ -22591,7 +22591,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -22632,17 +22632,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "skills",
+            "name": "skill",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -22652,21 +22642,31 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "SCALAR",
-              "name": "String",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null
           },
           {
-            "name": "users",
+            "name": "user",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "users_obj_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
@@ -22706,7 +22706,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -22718,7 +22718,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "args": [],
             "type": {
@@ -22762,7 +22762,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -22772,7 +22772,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -22816,7 +22816,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -22828,7 +22828,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "args": [],
             "type": {
@@ -22872,7 +22872,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -22882,7 +22882,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23066,17 +23066,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "skills",
+            "name": "skill",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -23086,7 +23076,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23096,11 +23086,21 @@
             "defaultValue": null
           },
           {
-            "name": "users",
+            "name": "user",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "users_order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
               "ofType": null
             },
             "defaultValue": null
@@ -23156,13 +23156,13 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -23197,7 +23197,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -23207,7 +23207,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -23251,7 +23251,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -23295,7 +23295,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23339,7 +23339,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -23383,7 +23383,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23427,7 +23427,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -23471,7 +23471,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23515,7 +23515,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -23559,7 +23559,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23594,13 +23594,13 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "user_id",
+            "name": "userId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -23638,7 +23638,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -23682,7 +23682,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23726,7 +23726,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -23770,7 +23770,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23814,7 +23814,7 @@
             "deprecationReason": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "args": [],
             "type": {
@@ -23858,7 +23858,7 @@
             "defaultValue": null
           },
           {
-            "name": "skill_id",
+            "name": "skillId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -23890,7 +23890,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_users",
+            "name": "circleUsers",
             "description": "An array relationship",
             "args": [
               {
@@ -23981,7 +23981,7 @@
             "deprecationReason": null
           },
           {
-            "name": "circle_users_aggregate",
+            "name": "circleUsers_aggregate",
             "description": "An aggregated array relationship",
             "args": [
               {
@@ -24238,7 +24238,7 @@
             "deprecationReason": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "args": [],
             "type": {
@@ -24278,7 +24278,7 @@
             "deprecationReason": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "args": [],
             "type": {
@@ -24302,7 +24302,7 @@
             "deprecationReason": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "args": [],
             "type": {
@@ -24500,7 +24500,7 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "args": [],
             "type": {
@@ -24524,7 +24524,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_skills",
+            "name": "userSkills",
             "description": "An array relationship",
             "args": [
               {
@@ -24615,7 +24615,7 @@
             "deprecationReason": null
           },
           {
-            "name": "user_skills_aggregate",
+            "name": "userSkills_aggregate",
             "description": "An aggregated array relationship",
             "args": [
               {
@@ -24977,7 +24977,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_users",
+            "name": "circleUsers",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -24997,7 +24997,7 @@
             "defaultValue": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -25027,7 +25027,7 @@
             "defaultValue": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -25047,7 +25047,7 @@
             "defaultValue": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -25077,7 +25077,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -25097,7 +25097,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_skills",
+            "name": "userSkills",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -25155,7 +25155,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_users",
+            "name": "circleUsers",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -25175,7 +25175,7 @@
             "defaultValue": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -25205,7 +25205,7 @@
             "defaultValue": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -25225,7 +25225,7 @@
             "defaultValue": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -25255,7 +25255,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -25275,7 +25275,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_skills",
+            "name": "userSkills",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -25317,7 +25317,7 @@
             "deprecationReason": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "args": [],
             "type": {
@@ -25353,7 +25353,7 @@
             "deprecationReason": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "args": [],
             "type": {
@@ -25377,7 +25377,7 @@
             "deprecationReason": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "args": [],
             "type": {
@@ -25401,7 +25401,7 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "args": [],
             "type": {
@@ -25435,7 +25435,7 @@
             "defaultValue": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25465,7 +25465,7 @@
             "defaultValue": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25485,7 +25485,7 @@
             "defaultValue": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25505,7 +25505,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25537,7 +25537,7 @@
             "deprecationReason": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "args": [],
             "type": {
@@ -25573,7 +25573,7 @@
             "deprecationReason": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "args": [],
             "type": {
@@ -25597,7 +25597,7 @@
             "deprecationReason": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "args": [],
             "type": {
@@ -25621,7 +25621,7 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "args": [],
             "type": {
@@ -25655,7 +25655,7 @@
             "defaultValue": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25685,7 +25685,7 @@
             "defaultValue": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25705,7 +25705,7 @@
             "defaultValue": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25725,7 +25725,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25899,7 +25899,7 @@
             "defaultValue": null
           },
           {
-            "name": "circle_users_aggregate",
+            "name": "circleUsers_aggregate",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -25919,7 +25919,7 @@
             "defaultValue": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25949,7 +25949,7 @@
             "defaultValue": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25969,7 +25969,7 @@
             "defaultValue": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -25999,7 +25999,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -26019,7 +26019,7 @@
             "defaultValue": null
           },
           {
-            "name": "user_skills_aggregate",
+            "name": "userSkills_aggregate",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -26083,7 +26083,7 @@
             "deprecationReason": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -26101,7 +26101,7 @@
             "deprecationReason": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -26113,7 +26113,7 @@
             "deprecationReason": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -26125,7 +26125,7 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -26150,7 +26150,7 @@
             "defaultValue": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -26180,7 +26180,7 @@
             "defaultValue": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -26200,7 +26200,7 @@
             "defaultValue": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -26220,7 +26220,7 @@
             "defaultValue": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -26249,7 +26249,7 @@
             "deprecationReason": null
           },
           {
-            "name": "created_at",
+            "name": "createdAt",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -26267,7 +26267,7 @@
             "deprecationReason": null
           },
           {
-            "name": "interested_in",
+            "name": "interestedIn",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -26279,7 +26279,7 @@
             "deprecationReason": null
           },
           {
-            "name": "last_seen",
+            "name": "lastSeen",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -26291,7 +26291,7 @@
             "deprecationReason": null
           },
           {
-            "name": "organization_id",
+            "name": "organizationId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/web/graphql.schema.json
+++ b/packages/web/graphql.schema.json
@@ -4606,7 +4606,7 @@
             "deprecationReason": null
           },
           {
-            "name": "subCategories",
+            "name": "subCategory",
             "description": "An object relationship",
             "args": [],
             "type": {
@@ -5261,7 +5261,7 @@
             "defaultValue": null
           },
           {
-            "name": "subCategories",
+            "name": "subCategory",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -5470,7 +5470,7 @@
             "defaultValue": null
           },
           {
-            "name": "subCategories",
+            "name": "subCategory",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -6214,7 +6214,7 @@
             "defaultValue": null
           },
           {
-            "name": "subCategories",
+            "name": "subCategory",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",

--- a/packages/web/src/components/Molecules/Cards/CircleCard.tsx
+++ b/packages/web/src/components/Molecules/Cards/CircleCard.tsx
@@ -53,7 +53,7 @@ type Props = {
   // TODO: クエリ変更したら自動でタイプ変換できるようにしたい
   circle: Pick<
     Circles,
-    "id" | "name" | "avatar" | "what_we_will_do" | "main_role"
+    "id" | "name" | "avatar" | "whatWeWillDo" | "mainRole"
   >;
 };
 
@@ -76,7 +76,7 @@ const CircleCard: FC<Props> = ({ circle }) => {
         <People height="20px" width="20px" />
         30人
       </PeopleNum>
-      <Description>{circle.what_we_will_do}</Description>
+      <Description>{circle.whatWeWillDo}</Description>
     </StyledCard>
   );
 };

--- a/packages/web/src/components/Organisms/Cards/CircleCreateCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/CircleCreateCard.tsx
@@ -85,8 +85,8 @@ const CircleCreateCard: FC<Props> = (props) => {
           <DefaultInput
             onChange={handleChange}
             placeholder="募集の題名"
-            name="recruit_title"
-            value={props.inputs.recruit_title}
+            name="recruitTitle"
+            value={props.inputs.recruitTitle}
           />
           <div>
             <StyledSubTitle>カテゴリを選択</StyledSubTitle>
@@ -95,7 +95,7 @@ const CircleCreateCard: FC<Props> = (props) => {
             ) : (
               <StyledGrid height={30}>
                 <SubCategoryTags
-                  subCategories={data?.sub_categories}
+                  subCategories={data?.subCategories}
                   selectedCategory={props.selectedCategory}
                   setCategory={props.setCategory}
                 />
@@ -110,8 +110,8 @@ const CircleCreateCard: FC<Props> = (props) => {
             <DefaultTextArea
               onChange={handleChange}
               placeholder="あなたのサークルでやることを記入してください"
-              name="what_we_will_do"
-              value={props.inputs.what_we_will_do}
+              name="whatWeWillDo"
+              value={props.inputs.whatWeWillDo}
             />
           </Block>
           <Block>
@@ -119,8 +119,8 @@ const CircleCreateCard: FC<Props> = (props) => {
             <DefaultTextArea
               onChange={handleChange}
               placeholder="歓迎条件をご記入ください"
-              name="main_role"
-              value={props.inputs.main_role}
+              name="mainRole"
+              value={props.inputs.mainRole}
             />
           </Block>
           <Block>

--- a/packages/web/src/components/Organisms/Cards/CircleDetailCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/CircleDetailCard.tsx
@@ -101,11 +101,11 @@ const StyledGrid = styled.div<StyleGrid>`
 type Props = {
   circle: Pick<
     Circles,
-    "avatar" | "name" | "recruit_title" | "main_role" | "what_we_will_do"
+    "avatar" | "name" | "recruitTitle" | "mainRole" | "whatWeWillDo"
   > & {
-    circle_skills: { skills: Pick<Skills, "id" | "name" | "avatar"> }[];
+    circleSkills: { skill: Pick<Skills, "id" | "name" | "avatar"> }[];
   } & {
-    sub_categories?: Pick<Sub_Categories, "name"> | null;
+    subCategories?: Pick<Sub_Categories, "name"> | null;
   } & { owner?: Pick<Users, "id" | "name" | "avatar"> | null };
 };
 
@@ -123,9 +123,9 @@ const CircleDetailCard: FC<Props> = ({ circle }) => {
         <StyledCircleAvatar src={circle.avatar} size={66} />
         <StyledHeader>
           <StyledTitle>{circle.name}</StyledTitle>
-          <StyledCaption>{circle.recruit_title}</StyledCaption>
-          {circle.sub_categories?.name && (
-            <DefaultTag name={circle.sub_categories.name} />
+          <StyledCaption>{circle.recruitTitle}</StyledCaption>
+          {circle.subCategories?.name && (
+            <DefaultTag name={circle.subCategories.name} />
           )}
         </StyledHeader>
 
@@ -145,20 +145,20 @@ const CircleDetailCard: FC<Props> = ({ circle }) => {
 
       <StyledBlock>
         <StyledSubTitle>何をするのか</StyledSubTitle>
-        <StyledDesc>{circle.what_we_will_do}</StyledDesc>
+        <StyledDesc>{circle.whatWeWillDo}</StyledDesc>
       </StyledBlock>
       <StyledBlock>
         <StyledSubTitle>主な役割</StyledSubTitle>
-        <StyledDesc>{circle.main_role}</StyledDesc>
+        <StyledDesc>{circle.mainRole}</StyledDesc>
       </StyledBlock>
       <StyledBlock>
         <StyledSubTitle>使用する技術やアプリ</StyledSubTitle>
-        <StyledGrid height={Math.ceil(circle.circle_skills.length / 4) * 85}>
-          {circle.circle_skills?.map((circleSkill) => (
+        <StyledGrid height={Math.ceil(circle.circleSkills.length / 4) * 85}>
+          {circle.circleSkills?.map((circleSkill) => (
             <SkillCard
-              name={circleSkill.skills.name}
-              id={circleSkill.skills.id.toString()}
-              avatar={circleSkill.skills.avatar}
+              name={circleSkill.skill.name}
+              id={circleSkill.skill.id.toString()}
+              avatar={circleSkill.skill.avatar}
             />
           ))}
         </StyledGrid>

--- a/packages/web/src/components/Organisms/Cards/SelectCategoryCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/SelectCategoryCard.tsx
@@ -37,11 +37,11 @@ const SelectCategoryCard: FC<Props> = ({
   return (
     <StyledCard>
       <StyledH3>カテゴリー選択</StyledH3>
-      {data?.parent_categories.map((parentCategory) => {
+      {data?.parentCategories.map((parentCategory) => {
         return (
           <CheckBoxStagesList
             parentItem={parentCategory}
-            childrenItems={parentCategory.sub_categories}
+            childrenItems={parentCategory.subCategories}
             key={parentCategory.id}
             selectedChildrenIds={selectedSubcategories}
             setChildrenIds={setSubCategories}

--- a/packages/web/src/components/Organisms/Cards/UserDetailCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/UserDetailCard.tsx
@@ -55,20 +55,20 @@ const StyledCircleList = styled.div`
 
 const UserDetailCard: FC<Props> = ({ data }) => {
   const skillCardHeight = useMemo(
-    () => data.user && Math.ceil(data.user.user_skills.length / 4) * 75,
+    () => data.user && Math.ceil(data.user.userSkills.length / 4) * 75,
     [data]
   );
 
   const circleCardHeight = useMemo(
-    () => (data.user?.circle_users.length || 0) * 75,
+    () => (data.user?.circleUsers.length || 0) * 75,
     [data]
   );
 
   if (data.user == null) return <p>ユーザーが存在しません</p>;
 
   const user = data.user;
-  const skills = user.user_skills.map((skill) => skill.skills);
-  const circles = user.circle_users.map((circle_user) => circle_user.circle);
+  const skills = user.userSkills.map((userSkill) => userSkill.skill);
+  const circles = user.circleUsers.map((circleUser) => circleUser.circle);
 
   return (
     <StyledCard>
@@ -83,7 +83,7 @@ const UserDetailCard: FC<Props> = ({ data }) => {
       </StyledBlock>
       <StyledBlock>
         <StyledSubTitle>興味のあること</StyledSubTitle>
-        <StyledDesc>{user.interested_in}</StyledDesc>
+        <StyledDesc>{user.interestedIn}</StyledDesc>
       </StyledBlock>
       <StyledBlock>
         <StyledSubTitle>スキル一覧</StyledSubTitle>

--- a/packages/web/src/components/Organisms/Cards/UserEditCard.tsx
+++ b/packages/web/src/components/Organisms/Cards/UserEditCard.tsx
@@ -97,8 +97,8 @@ const UserEditCard: FC<Props> = (props) => {
           <DefaultTextArea
             onChange={handleChange}
             placeholder="自己紹介を記入してください"
-            name="interested_in"
-            value={props.inputs.interested_in}
+            name="interestedIn"
+            value={props.inputs.interestedIn}
           />
         </StyledDesc>
       </StyledBlock>

--- a/packages/web/src/components/Pages/CircleCreatePage.tsx
+++ b/packages/web/src/components/Pages/CircleCreatePage.tsx
@@ -15,9 +15,9 @@ const RightButton = styled.div`
 
 export type Input = {
   name: string;
-  recruit_title: string;
-  what_we_will_do: string;
-  main_role: string;
+  recruitTitle: string;
+  whatWeWillDo: string;
+  mainRole: string;
 };
 
 const CircleCreatePage: FC = () => {
@@ -25,15 +25,15 @@ const CircleCreatePage: FC = () => {
   const [selectedCategory, setCategory] = useState<number>(0);
   const [inputs, setInputs] = useState<Input>({
     name: "",
-    recruit_title: "",
-    what_we_will_do: "",
-    main_role: "",
+    recruitTitle: "",
+    whatWeWillDo: "",
+    mainRole: "",
   });
 
   const [buttonText, setText] = useState("作成する");
 
   const skills = selectedSkills.map((skill: number) => ({
-    skills: {
+    skill: {
       data: { id: skill, avatar: "", name: "" },
       on_conflict: {
         constraint: Skills_Constraint.SkillPkey,
@@ -50,8 +50,8 @@ const CircleCreatePage: FC = () => {
         objects: [
           {
             ...inputs,
-            sub_category_id: selectedCategory,
-            circle_skills:{
+            subCategoryId: selectedCategory,
+            circleSkills:{
               data: [...skills],
             }
           },

--- a/packages/web/src/components/Pages/CircleEditPage.tsx
+++ b/packages/web/src/components/Pages/CircleEditPage.tsx
@@ -18,9 +18,9 @@ const RightButton = styled.div`
 
 type Input = {
   name: string;
-  recruit_title: string;
-  what_we_will_do: string;
-  main_role: string;
+  recruitTitle: string;
+  whatWeWillDo: string;
+  mainRole: string;
 };
 
 type Params = {
@@ -36,9 +36,9 @@ const CircleEditPage: React.FC = () => {
   const [selectedCategory, setCategory] = useState<number>(0);
   const [inputs, setInputs] = useState<Input>({
     name: "",
-    recruit_title: "",
-    what_we_will_do: "",
-    main_role: "",
+    recruitTitle: "",
+    whatWeWillDo: "",
+    mainRole: "",
   });
   const [buttonText, setText] = useState("更新する");
 
@@ -55,12 +55,12 @@ const CircleEditPage: React.FC = () => {
       if (circle) {
         setInputs({
           name: circle.name || "",
-          recruit_title: circle.recruit_title || "",
-          what_we_will_do: circle.what_we_will_do || "",
-          main_role: circle.main_role || "",
+          recruitTitle: circle.recruitTitle || "",
+          whatWeWillDo: circle.whatWeWillDo || "",
+          mainRole: circle.mainRole || "",
         });
-        const skills = circle.circle_skills.map((skill) => skill.skills.id) || [];
-        const category = circle.sub_categories?.id;
+        const skills = circle.circleSkills.map((circleSkill) => circleSkill.skill.id) || [];
+        const category = circle.subCategory?.id;
         setSkills(skills);
         setInitSkills(skills);
         console.log(category);
@@ -128,7 +128,7 @@ const CircleEditPage: React.FC = () => {
         id: circleId,
         inputs: {
           ...inputs,
-          sub_category_id: selectedCategory,
+          subCategoryId: selectedCategory,
         },
       },
     });

--- a/packages/web/src/components/Pages/CircleListPage.tsx
+++ b/packages/web/src/components/Pages/CircleListPage.tsx
@@ -34,7 +34,7 @@ const CircleListPage: FC = () => {
   const where = useMemo(() => {
     return selectedSubcategories.length
       ? {
-          sub_categories: {
+          subCategory: {
             id: {
               _in: selectedSubcategories,
             },

--- a/packages/web/src/components/Pages/UserEditPage.tsx
+++ b/packages/web/src/components/Pages/UserEditPage.tsx
@@ -23,7 +23,7 @@ type Params = {
 
 export type UserEditInput = {
   name: string;
-  interested_in: string;
+  interestedIn: string;
   introduction: string;
 };
 
@@ -36,7 +36,7 @@ const UserEditPage: React.FC = () => {
   const userId = state.userId;
   const [inputs, setInputs] = useState<UserEditInput>({
     name: "",
-    interested_in: "",
+    interestedIn: "",
     introduction: "",
   });
   const { data, loading, error } = useUserQuery({
@@ -61,9 +61,9 @@ const UserEditPage: React.FC = () => {
         setInputs({
           name: user.name || "",
           introduction: user.introduction || "",
-          interested_in: user.interested_in || "",
+          interestedIn: user.interestedIn || "",
         });
-        const skills = user.user_skills.map((skill) => skill.skills.id) || [];
+        const skills = user.userSkills.map((user_skill) => user_skill.skill.id) || [];
         setSkills(skills);
         setInitSkills(skills);
       }

--- a/packages/web/src/generated/graphql.tsx
+++ b/packages/web/src/generated/graphql.tsx
@@ -1,9 +1,7 @@
-import { gql } from "@apollo/client";
-import * as Apollo from "@apollo/client";
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -16,60 +14,60 @@ export type Scalars = {
 
 /** expression to compare columns of type Int. All fields are combined with logical 'AND'. */
 export type Int_Comparison_Exp = {
-  _eq?: Maybe<Scalars["Int"]>;
-  _gt?: Maybe<Scalars["Int"]>;
-  _gte?: Maybe<Scalars["Int"]>;
-  _in?: Maybe<Array<Scalars["Int"]>>;
-  _is_null?: Maybe<Scalars["Boolean"]>;
-  _lt?: Maybe<Scalars["Int"]>;
-  _lte?: Maybe<Scalars["Int"]>;
-  _neq?: Maybe<Scalars["Int"]>;
-  _nin?: Maybe<Array<Scalars["Int"]>>;
+  _eq?: Maybe<Scalars['Int']>;
+  _gt?: Maybe<Scalars['Int']>;
+  _gte?: Maybe<Scalars['Int']>;
+  _in?: Maybe<Array<Scalars['Int']>>;
+  _is_null?: Maybe<Scalars['Boolean']>;
+  _lt?: Maybe<Scalars['Int']>;
+  _lte?: Maybe<Scalars['Int']>;
+  _neq?: Maybe<Scalars['Int']>;
+  _nin?: Maybe<Array<Scalars['Int']>>;
 };
 
 /** expression to compare columns of type String. All fields are combined with logical 'AND'. */
 export type String_Comparison_Exp = {
-  _eq?: Maybe<Scalars["String"]>;
-  _gt?: Maybe<Scalars["String"]>;
-  _gte?: Maybe<Scalars["String"]>;
-  _ilike?: Maybe<Scalars["String"]>;
-  _in?: Maybe<Array<Scalars["String"]>>;
-  _is_null?: Maybe<Scalars["Boolean"]>;
-  _like?: Maybe<Scalars["String"]>;
-  _lt?: Maybe<Scalars["String"]>;
-  _lte?: Maybe<Scalars["String"]>;
-  _neq?: Maybe<Scalars["String"]>;
-  _nilike?: Maybe<Scalars["String"]>;
-  _nin?: Maybe<Array<Scalars["String"]>>;
-  _nlike?: Maybe<Scalars["String"]>;
-  _nsimilar?: Maybe<Scalars["String"]>;
-  _similar?: Maybe<Scalars["String"]>;
+  _eq?: Maybe<Scalars['String']>;
+  _gt?: Maybe<Scalars['String']>;
+  _gte?: Maybe<Scalars['String']>;
+  _ilike?: Maybe<Scalars['String']>;
+  _in?: Maybe<Array<Scalars['String']>>;
+  _is_null?: Maybe<Scalars['Boolean']>;
+  _like?: Maybe<Scalars['String']>;
+  _lt?: Maybe<Scalars['String']>;
+  _lte?: Maybe<Scalars['String']>;
+  _neq?: Maybe<Scalars['String']>;
+  _nilike?: Maybe<Scalars['String']>;
+  _nin?: Maybe<Array<Scalars['String']>>;
+  _nlike?: Maybe<Scalars['String']>;
+  _nsimilar?: Maybe<Scalars['String']>;
+  _similar?: Maybe<Scalars['String']>;
 };
 
 /** columns and relationships of "circle_skills" */
 export type Circle_Skills = {
-  __typename?: "circle_skills";
-  circle_id: Scalars["Int"];
+  __typename?: 'circle_skills';
   /** An object relationship */
-  circles: Circles;
-  id: Scalars["Int"];
-  skill_id: Scalars["Int"];
+  circle: Circles;
+  circleId: Scalars['Int'];
+  id: Scalars['Int'];
   /** An object relationship */
-  skills: Skills;
+  skill: Skills;
+  skillId: Scalars['Int'];
 };
 
 /** aggregated selection of "circle_skills" */
 export type Circle_Skills_Aggregate = {
-  __typename?: "circle_skills_aggregate";
+  __typename?: 'circle_skills_aggregate';
   aggregate?: Maybe<Circle_Skills_Aggregate_Fields>;
   nodes: Array<Circle_Skills>;
 };
 
 /** aggregate fields of "circle_skills" */
 export type Circle_Skills_Aggregate_Fields = {
-  __typename?: "circle_skills_aggregate_fields";
+  __typename?: 'circle_skills_aggregate_fields';
   avg?: Maybe<Circle_Skills_Avg_Fields>;
-  count?: Maybe<Scalars["Int"]>;
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Circle_Skills_Max_Fields>;
   min?: Maybe<Circle_Skills_Min_Fields>;
   stddev?: Maybe<Circle_Skills_Stddev_Fields>;
@@ -81,10 +79,11 @@ export type Circle_Skills_Aggregate_Fields = {
   variance?: Maybe<Circle_Skills_Variance_Fields>;
 };
 
+
 /** aggregate fields of "circle_skills" */
 export type Circle_Skills_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Circle_Skills_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "circle_skills" */
@@ -110,17 +109,17 @@ export type Circle_Skills_Arr_Rel_Insert_Input = {
 
 /** aggregate avg on columns */
 export type Circle_Skills_Avg_Fields = {
-  __typename?: "circle_skills_avg_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_skills_avg_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "circle_skills" */
 export type Circle_Skills_Avg_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "circle_skills". All fields are combined with a logical 'AND'. */
@@ -128,70 +127,70 @@ export type Circle_Skills_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Circle_Skills_Bool_Exp>>>;
   _not?: Maybe<Circle_Skills_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Circle_Skills_Bool_Exp>>>;
-  circle_id?: Maybe<Int_Comparison_Exp>;
-  circles?: Maybe<Circles_Bool_Exp>;
+  circle?: Maybe<Circles_Bool_Exp>;
+  circleId?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
-  skill_id?: Maybe<Int_Comparison_Exp>;
-  skills?: Maybe<Skills_Bool_Exp>;
+  skill?: Maybe<Skills_Bool_Exp>;
+  skillId?: Maybe<Int_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "circle_skills" */
 export enum Circle_Skills_Constraint {
   /** unique or primary key constraint */
-  CircleSkillsPkey = "circle_skills_pkey",
+  CircleSkillsPkey = 'circle_skills_pkey'
 }
 
 /** input type for incrementing integer column in table "circle_skills" */
 export type Circle_Skills_Inc_Input = {
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "circle_skills" */
 export type Circle_Skills_Insert_Input = {
-  circle_id?: Maybe<Scalars["Int"]>;
-  circles?: Maybe<Circles_Obj_Rel_Insert_Input>;
-  id?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
-  skills?: Maybe<Skills_Obj_Rel_Insert_Input>;
+  circle?: Maybe<Circles_Obj_Rel_Insert_Input>;
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  skill?: Maybe<Skills_Obj_Rel_Insert_Input>;
+  skillId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Circle_Skills_Max_Fields = {
-  __typename?: "circle_skills_max_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
+  __typename?: 'circle_skills_max_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "circle_skills" */
 export type Circle_Skills_Max_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Circle_Skills_Min_Fields = {
-  __typename?: "circle_skills_min_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
+  __typename?: 'circle_skills_min_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "circle_skills" */
 export type Circle_Skills_Min_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "circle_skills" */
 export type Circle_Skills_Mutation_Response = {
-  __typename?: "circle_skills_mutation_response";
+  __typename?: 'circle_skills_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Circle_Skills>;
 };
@@ -211,174 +210,174 @@ export type Circle_Skills_On_Conflict = {
 
 /** ordering options when selecting data from "circle_skills" */
 export type Circle_Skills_Order_By = {
-  circle_id?: Maybe<Order_By>;
-  circles?: Maybe<Circles_Order_By>;
+  circle?: Maybe<Circles_Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
-  skills?: Maybe<Skills_Order_By>;
+  skill?: Maybe<Skills_Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "circle_skills" */
 export type Circle_Skills_Pk_Columns_Input = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
 
 /** select columns of table "circle_skills" */
 export enum Circle_Skills_Select_Column {
   /** column name */
-  CircleId = "circle_id",
+  CircleId = 'circleId',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  SkillId = "skill_id",
+  SkillId = 'skillId'
 }
 
 /** input type for updating data in table "circle_skills" */
 export type Circle_Skills_Set_Input = {
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type Circle_Skills_Stddev_Fields = {
-  __typename?: "circle_skills_stddev_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_skills_stddev_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "circle_skills" */
 export type Circle_Skills_Stddev_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Circle_Skills_Stddev_Pop_Fields = {
-  __typename?: "circle_skills_stddev_pop_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_skills_stddev_pop_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "circle_skills" */
 export type Circle_Skills_Stddev_Pop_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Circle_Skills_Stddev_Samp_Fields = {
-  __typename?: "circle_skills_stddev_samp_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_skills_stddev_samp_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "circle_skills" */
 export type Circle_Skills_Stddev_Samp_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Circle_Skills_Sum_Fields = {
-  __typename?: "circle_skills_sum_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
+  __typename?: 'circle_skills_sum_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "circle_skills" */
 export type Circle_Skills_Sum_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** update columns of table "circle_skills" */
 export enum Circle_Skills_Update_Column {
   /** column name */
-  CircleId = "circle_id",
+  CircleId = 'circleId',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  SkillId = "skill_id",
+  SkillId = 'skillId'
 }
 
 /** aggregate var_pop on columns */
 export type Circle_Skills_Var_Pop_Fields = {
-  __typename?: "circle_skills_var_pop_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_skills_var_pop_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "circle_skills" */
 export type Circle_Skills_Var_Pop_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Circle_Skills_Var_Samp_Fields = {
-  __typename?: "circle_skills_var_samp_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_skills_var_samp_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "circle_skills" */
 export type Circle_Skills_Var_Samp_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Circle_Skills_Variance_Fields = {
-  __typename?: "circle_skills_variance_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_skills_variance_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "circle_skills" */
 export type Circle_Skills_Variance_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "circle_users" */
 export type Circle_Users = {
-  __typename?: "circle_users";
+  __typename?: 'circle_users';
   /** An object relationship */
   circle: Circles;
-  circle_id: Scalars["Int"];
-  id: Scalars["Int"];
-  user_id: Scalars["String"];
+  circleId: Scalars['Int'];
+  id: Scalars['Int'];
   /** An object relationship */
-  users: Users;
+  user: Users;
+  userId: Scalars['String'];
 };
 
 /** aggregated selection of "circle_users" */
 export type Circle_Users_Aggregate = {
-  __typename?: "circle_users_aggregate";
+  __typename?: 'circle_users_aggregate';
   aggregate?: Maybe<Circle_Users_Aggregate_Fields>;
   nodes: Array<Circle_Users>;
 };
 
 /** aggregate fields of "circle_users" */
 export type Circle_Users_Aggregate_Fields = {
-  __typename?: "circle_users_aggregate_fields";
+  __typename?: 'circle_users_aggregate_fields';
   avg?: Maybe<Circle_Users_Avg_Fields>;
-  count?: Maybe<Scalars["Int"]>;
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Circle_Users_Max_Fields>;
   min?: Maybe<Circle_Users_Min_Fields>;
   stddev?: Maybe<Circle_Users_Stddev_Fields>;
@@ -390,10 +389,11 @@ export type Circle_Users_Aggregate_Fields = {
   variance?: Maybe<Circle_Users_Variance_Fields>;
 };
 
+
 /** aggregate fields of "circle_users" */
 export type Circle_Users_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Circle_Users_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "circle_users" */
@@ -419,14 +419,14 @@ export type Circle_Users_Arr_Rel_Insert_Input = {
 
 /** aggregate avg on columns */
 export type Circle_Users_Avg_Fields = {
-  __typename?: "circle_users_avg_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_users_avg_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "circle_users" */
 export type Circle_Users_Avg_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -436,68 +436,68 @@ export type Circle_Users_Bool_Exp = {
   _not?: Maybe<Circle_Users_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Circle_Users_Bool_Exp>>>;
   circle?: Maybe<Circles_Bool_Exp>;
-  circle_id?: Maybe<Int_Comparison_Exp>;
+  circleId?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
-  user_id?: Maybe<String_Comparison_Exp>;
-  users?: Maybe<Users_Bool_Exp>;
+  user?: Maybe<Users_Bool_Exp>;
+  userId?: Maybe<String_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "circle_users" */
 export enum Circle_Users_Constraint {
   /** unique or primary key constraint */
-  RoomUserPkey = "RoomUser_pkey",
+  RoomUserPkey = 'RoomUser_pkey'
 }
 
 /** input type for incrementing integer column in table "circle_users" */
 export type Circle_Users_Inc_Input = {
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "circle_users" */
 export type Circle_Users_Insert_Input = {
   circle?: Maybe<Circles_Obj_Rel_Insert_Input>;
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  user_id?: Maybe<Scalars["String"]>;
-  users?: Maybe<Users_Obj_Rel_Insert_Input>;
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  user?: Maybe<Users_Obj_Rel_Insert_Input>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** aggregate max on columns */
 export type Circle_Users_Max_Fields = {
-  __typename?: "circle_users_max_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  __typename?: 'circle_users_max_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "circle_users" */
 export type Circle_Users_Max_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Circle_Users_Min_Fields = {
-  __typename?: "circle_users_min_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  __typename?: 'circle_users_min_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "circle_users" */
 export type Circle_Users_Min_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "circle_users" */
 export type Circle_Users_Mutation_Response = {
-  __typename?: "circle_users_mutation_response";
+  __typename?: 'circle_users_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Circle_Users>;
 };
@@ -518,233 +518,239 @@ export type Circle_Users_On_Conflict = {
 /** ordering options when selecting data from "circle_users" */
 export type Circle_Users_Order_By = {
   circle?: Maybe<Circles_Order_By>;
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-  users?: Maybe<Users_Order_By>;
+  user?: Maybe<Users_Order_By>;
+  userId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "circle_users" */
 export type Circle_Users_Pk_Columns_Input = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
 
 /** select columns of table "circle_users" */
 export enum Circle_Users_Select_Column {
   /** column name */
-  CircleId = "circle_id",
+  CircleId = 'circleId',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  UserId = "user_id",
+  UserId = 'userId'
 }
 
 /** input type for updating data in table "circle_users" */
 export type Circle_Users_Set_Input = {
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** aggregate stddev on columns */
 export type Circle_Users_Stddev_Fields = {
-  __typename?: "circle_users_stddev_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_users_stddev_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "circle_users" */
 export type Circle_Users_Stddev_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Circle_Users_Stddev_Pop_Fields = {
-  __typename?: "circle_users_stddev_pop_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_users_stddev_pop_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "circle_users" */
 export type Circle_Users_Stddev_Pop_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Circle_Users_Stddev_Samp_Fields = {
-  __typename?: "circle_users_stddev_samp_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_users_stddev_samp_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "circle_users" */
 export type Circle_Users_Stddev_Samp_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Circle_Users_Sum_Fields = {
-  __typename?: "circle_users_sum_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
+  __typename?: 'circle_users_sum_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "circle_users" */
 export type Circle_Users_Sum_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** update columns of table "circle_users" */
 export enum Circle_Users_Update_Column {
   /** column name */
-  CircleId = "circle_id",
+  CircleId = 'circleId',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  UserId = "user_id",
+  UserId = 'userId'
 }
 
 /** aggregate var_pop on columns */
 export type Circle_Users_Var_Pop_Fields = {
-  __typename?: "circle_users_var_pop_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_users_var_pop_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "circle_users" */
 export type Circle_Users_Var_Pop_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Circle_Users_Var_Samp_Fields = {
-  __typename?: "circle_users_var_samp_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_users_var_samp_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "circle_users" */
 export type Circle_Users_Var_Samp_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Circle_Users_Variance_Fields = {
-  __typename?: "circle_users_variance_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circle_users_variance_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "circle_users" */
 export type Circle_Users_Variance_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "circles" */
 export type Circles = {
-  __typename?: "circles";
-  avatar: Scalars["String"];
+  __typename?: 'circles';
+  avatar: Scalars['String'];
   /** An array relationship */
-  circle_skills: Array<Circle_Skills>;
+  circleSkills: Array<Circle_Skills>;
   /** An aggregated array relationship */
-  circle_skills_aggregate: Circle_Skills_Aggregate;
+  circleSkills_aggregate: Circle_Skills_Aggregate;
   /** An array relationship */
-  circle_users: Array<Circle_Users>;
+  circleUsers: Array<Circle_Users>;
   /** An aggregated array relationship */
-  circle_users_aggregate: Circle_Users_Aggregate;
-  id: Scalars["Int"];
-  main_role?: Maybe<Scalars["String"]>;
+  circleUsers_aggregate: Circle_Users_Aggregate;
+  id: Scalars['Int'];
+  mainRole?: Maybe<Scalars['String']>;
   /** An array relationship */
   messages: Array<Messages>;
   /** An aggregated array relationship */
   messages_aggregate: Messages_Aggregate;
-  name: Scalars["String"];
-  organization_id?: Maybe<Scalars["String"]>;
+  name: Scalars['String'];
+  organizationId?: Maybe<Scalars['String']>;
   /** An object relationship */
   organizations?: Maybe<Organizations>;
-  owner_id?: Maybe<Scalars["String"]>;
-  recruit_title?: Maybe<Scalars["String"]>;
   /** An object relationship */
-  sub_categories?: Maybe<Sub_Categories>;
-  sub_category_id?: Maybe<Scalars["Int"]>;
+  owner?: Maybe<Users>;
+  ownerId?: Maybe<Scalars['String']>;
+  recruitTitle?: Maybe<Scalars['String']>;
   /** An object relationship */
-  users?: Maybe<Users>;
-  what_we_will_do?: Maybe<Scalars["String"]>;
+  subCategories?: Maybe<Sub_Categories>;
+  subCategoryId?: Maybe<Scalars['Int']>;
+  whatWeWillDo?: Maybe<Scalars['String']>;
 };
 
+
 /** columns and relationships of "circles" */
-export type CirclesCircle_SkillsArgs = {
+export type CirclesCircleSkillsArgs = {
   distinct_on?: Maybe<Array<Circle_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Skills_Order_By>>;
   where?: Maybe<Circle_Skills_Bool_Exp>;
 };
 
+
 /** columns and relationships of "circles" */
-export type CirclesCircle_Skills_AggregateArgs = {
+export type CirclesCircleSkills_AggregateArgs = {
   distinct_on?: Maybe<Array<Circle_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Skills_Order_By>>;
   where?: Maybe<Circle_Skills_Bool_Exp>;
 };
 
+
 /** columns and relationships of "circles" */
-export type CirclesCircle_UsersArgs = {
+export type CirclesCircleUsersArgs = {
   distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Users_Order_By>>;
   where?: Maybe<Circle_Users_Bool_Exp>;
 };
 
+
 /** columns and relationships of "circles" */
-export type CirclesCircle_Users_AggregateArgs = {
+export type CirclesCircleUsers_AggregateArgs = {
   distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Users_Order_By>>;
   where?: Maybe<Circle_Users_Bool_Exp>;
 };
+
 
 /** columns and relationships of "circles" */
 export type CirclesMessagesArgs = {
   distinct_on?: Maybe<Array<Messages_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Messages_Order_By>>;
   where?: Maybe<Messages_Bool_Exp>;
 };
 
+
 /** columns and relationships of "circles" */
 export type CirclesMessages_AggregateArgs = {
   distinct_on?: Maybe<Array<Messages_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Messages_Order_By>>;
   where?: Maybe<Messages_Bool_Exp>;
 };
 
 /** aggregated selection of "circles" */
 export type Circles_Aggregate = {
-  __typename?: "circles_aggregate";
+  __typename?: 'circles_aggregate';
   aggregate?: Maybe<Circles_Aggregate_Fields>;
   nodes: Array<Circles>;
 };
 
 /** aggregate fields of "circles" */
 export type Circles_Aggregate_Fields = {
-  __typename?: "circles_aggregate_fields";
+  __typename?: 'circles_aggregate_fields';
   avg?: Maybe<Circles_Avg_Fields>;
-  count?: Maybe<Scalars["Int"]>;
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Circles_Max_Fields>;
   min?: Maybe<Circles_Min_Fields>;
   stddev?: Maybe<Circles_Stddev_Fields>;
@@ -756,10 +762,11 @@ export type Circles_Aggregate_Fields = {
   variance?: Maybe<Circles_Variance_Fields>;
 };
 
+
 /** aggregate fields of "circles" */
 export type Circles_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Circles_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "circles" */
@@ -785,15 +792,15 @@ export type Circles_Arr_Rel_Insert_Input = {
 
 /** aggregate avg on columns */
 export type Circles_Avg_Fields = {
-  __typename?: "circles_avg_fields";
-  id?: Maybe<Scalars["Float"]>;
-  sub_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circles_avg_fields';
+  id?: Maybe<Scalars['Float']>;
+  subCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "circles" */
 export type Circles_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "circles". All fields are combined with a logical 'AND'. */
@@ -802,112 +809,112 @@ export type Circles_Bool_Exp = {
   _not?: Maybe<Circles_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Circles_Bool_Exp>>>;
   avatar?: Maybe<String_Comparison_Exp>;
-  circle_skills?: Maybe<Circle_Skills_Bool_Exp>;
-  circle_users?: Maybe<Circle_Users_Bool_Exp>;
+  circleSkills?: Maybe<Circle_Skills_Bool_Exp>;
+  circleUsers?: Maybe<Circle_Users_Bool_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
-  main_role?: Maybe<String_Comparison_Exp>;
+  mainRole?: Maybe<String_Comparison_Exp>;
   messages?: Maybe<Messages_Bool_Exp>;
   name?: Maybe<String_Comparison_Exp>;
-  organization_id?: Maybe<String_Comparison_Exp>;
+  organizationId?: Maybe<String_Comparison_Exp>;
   organizations?: Maybe<Organizations_Bool_Exp>;
-  owner_id?: Maybe<String_Comparison_Exp>;
-  recruit_title?: Maybe<String_Comparison_Exp>;
-  sub_categories?: Maybe<Sub_Categories_Bool_Exp>;
-  sub_category_id?: Maybe<Int_Comparison_Exp>;
-  users?: Maybe<Users_Bool_Exp>;
-  what_we_will_do?: Maybe<String_Comparison_Exp>;
+  owner?: Maybe<Users_Bool_Exp>;
+  ownerId?: Maybe<String_Comparison_Exp>;
+  recruitTitle?: Maybe<String_Comparison_Exp>;
+  subCategories?: Maybe<Sub_Categories_Bool_Exp>;
+  subCategoryId?: Maybe<Int_Comparison_Exp>;
+  whatWeWillDo?: Maybe<String_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "circles" */
 export enum Circles_Constraint {
   /** unique or primary key constraint */
-  RoomsPkey = "rooms_pkey",
+  RoomsPkey = 'rooms_pkey'
 }
 
 /** input type for incrementing integer column in table "circles" */
 export type Circles_Inc_Input = {
-  id?: Maybe<Scalars["Int"]>;
-  sub_category_id?: Maybe<Scalars["Int"]>;
+  id?: Maybe<Scalars['Int']>;
+  subCategoryId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "circles" */
 export type Circles_Insert_Input = {
-  avatar?: Maybe<Scalars["String"]>;
-  circle_skills?: Maybe<Circle_Skills_Arr_Rel_Insert_Input>;
-  circle_users?: Maybe<Circle_Users_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars["Int"]>;
-  main_role?: Maybe<Scalars["String"]>;
+  avatar?: Maybe<Scalars['String']>;
+  circleSkills?: Maybe<Circle_Skills_Arr_Rel_Insert_Input>;
+  circleUsers?: Maybe<Circle_Users_Arr_Rel_Insert_Input>;
+  id?: Maybe<Scalars['Int']>;
+  mainRole?: Maybe<Scalars['String']>;
   messages?: Maybe<Messages_Arr_Rel_Insert_Input>;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
   organizations?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  owner_id?: Maybe<Scalars["String"]>;
-  recruit_title?: Maybe<Scalars["String"]>;
-  sub_categories?: Maybe<Sub_Categories_Obj_Rel_Insert_Input>;
-  sub_category_id?: Maybe<Scalars["Int"]>;
-  users?: Maybe<Users_Obj_Rel_Insert_Input>;
-  what_we_will_do?: Maybe<Scalars["String"]>;
+  owner?: Maybe<Users_Obj_Rel_Insert_Input>;
+  ownerId?: Maybe<Scalars['String']>;
+  recruitTitle?: Maybe<Scalars['String']>;
+  subCategories?: Maybe<Sub_Categories_Obj_Rel_Insert_Input>;
+  subCategoryId?: Maybe<Scalars['Int']>;
+  whatWeWillDo?: Maybe<Scalars['String']>;
 };
 
 /** aggregate max on columns */
 export type Circles_Max_Fields = {
-  __typename?: "circles_max_fields";
-  avatar?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["Int"]>;
-  main_role?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
-  owner_id?: Maybe<Scalars["String"]>;
-  recruit_title?: Maybe<Scalars["String"]>;
-  sub_category_id?: Maybe<Scalars["Int"]>;
-  what_we_will_do?: Maybe<Scalars["String"]>;
+  __typename?: 'circles_max_fields';
+  avatar?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['Int']>;
+  mainRole?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
+  ownerId?: Maybe<Scalars['String']>;
+  recruitTitle?: Maybe<Scalars['String']>;
+  subCategoryId?: Maybe<Scalars['Int']>;
+  whatWeWillDo?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "circles" */
 export type Circles_Max_Order_By = {
   avatar?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  main_role?: Maybe<Order_By>;
+  mainRole?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  owner_id?: Maybe<Order_By>;
-  recruit_title?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
-  what_we_will_do?: Maybe<Order_By>;
+  organizationId?: Maybe<Order_By>;
+  ownerId?: Maybe<Order_By>;
+  recruitTitle?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
+  whatWeWillDo?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Circles_Min_Fields = {
-  __typename?: "circles_min_fields";
-  avatar?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["Int"]>;
-  main_role?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
-  owner_id?: Maybe<Scalars["String"]>;
-  recruit_title?: Maybe<Scalars["String"]>;
-  sub_category_id?: Maybe<Scalars["Int"]>;
-  what_we_will_do?: Maybe<Scalars["String"]>;
+  __typename?: 'circles_min_fields';
+  avatar?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['Int']>;
+  mainRole?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
+  ownerId?: Maybe<Scalars['String']>;
+  recruitTitle?: Maybe<Scalars['String']>;
+  subCategoryId?: Maybe<Scalars['Int']>;
+  whatWeWillDo?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "circles" */
 export type Circles_Min_Order_By = {
   avatar?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  main_role?: Maybe<Order_By>;
+  mainRole?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  owner_id?: Maybe<Order_By>;
-  recruit_title?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
-  what_we_will_do?: Maybe<Order_By>;
+  organizationId?: Maybe<Order_By>;
+  ownerId?: Maybe<Order_By>;
+  recruitTitle?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
+  whatWeWillDo?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "circles" */
 export type Circles_Mutation_Response = {
-  __typename?: "circles_mutation_response";
+  __typename?: 'circles_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Circles>;
 };
@@ -928,201 +935,201 @@ export type Circles_On_Conflict = {
 /** ordering options when selecting data from "circles" */
 export type Circles_Order_By = {
   avatar?: Maybe<Order_By>;
-  circle_skills_aggregate?: Maybe<Circle_Skills_Aggregate_Order_By>;
-  circle_users_aggregate?: Maybe<Circle_Users_Aggregate_Order_By>;
+  circleSkills_aggregate?: Maybe<Circle_Skills_Aggregate_Order_By>;
+  circleUsers_aggregate?: Maybe<Circle_Users_Aggregate_Order_By>;
   id?: Maybe<Order_By>;
-  main_role?: Maybe<Order_By>;
+  mainRole?: Maybe<Order_By>;
   messages_aggregate?: Maybe<Messages_Aggregate_Order_By>;
   name?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
+  organizationId?: Maybe<Order_By>;
   organizations?: Maybe<Organizations_Order_By>;
-  owner_id?: Maybe<Order_By>;
-  recruit_title?: Maybe<Order_By>;
-  sub_categories?: Maybe<Sub_Categories_Order_By>;
-  sub_category_id?: Maybe<Order_By>;
-  users?: Maybe<Users_Order_By>;
-  what_we_will_do?: Maybe<Order_By>;
+  owner?: Maybe<Users_Order_By>;
+  ownerId?: Maybe<Order_By>;
+  recruitTitle?: Maybe<Order_By>;
+  subCategories?: Maybe<Sub_Categories_Order_By>;
+  subCategoryId?: Maybe<Order_By>;
+  whatWeWillDo?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "circles" */
 export type Circles_Pk_Columns_Input = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
 
 /** select columns of table "circles" */
 export enum Circles_Select_Column {
   /** column name */
-  Avatar = "avatar",
+  Avatar = 'avatar',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  MainRole = "main_role",
+  MainRole = 'mainRole',
   /** column name */
-  Name = "name",
+  Name = 'name',
   /** column name */
-  OrganizationId = "organization_id",
+  OrganizationId = 'organizationId',
   /** column name */
-  OwnerId = "owner_id",
+  OwnerId = 'ownerId',
   /** column name */
-  RecruitTitle = "recruit_title",
+  RecruitTitle = 'recruitTitle',
   /** column name */
-  SubCategoryId = "sub_category_id",
+  SubCategoryId = 'subCategoryId',
   /** column name */
-  WhatWeWillDo = "what_we_will_do",
+  WhatWeWillDo = 'whatWeWillDo'
 }
 
 /** input type for updating data in table "circles" */
 export type Circles_Set_Input = {
-  avatar?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["Int"]>;
-  main_role?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
-  owner_id?: Maybe<Scalars["String"]>;
-  recruit_title?: Maybe<Scalars["String"]>;
-  sub_category_id?: Maybe<Scalars["Int"]>;
-  what_we_will_do?: Maybe<Scalars["String"]>;
+  avatar?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['Int']>;
+  mainRole?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
+  ownerId?: Maybe<Scalars['String']>;
+  recruitTitle?: Maybe<Scalars['String']>;
+  subCategoryId?: Maybe<Scalars['Int']>;
+  whatWeWillDo?: Maybe<Scalars['String']>;
 };
 
 /** aggregate stddev on columns */
 export type Circles_Stddev_Fields = {
-  __typename?: "circles_stddev_fields";
-  id?: Maybe<Scalars["Float"]>;
-  sub_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circles_stddev_fields';
+  id?: Maybe<Scalars['Float']>;
+  subCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "circles" */
 export type Circles_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Circles_Stddev_Pop_Fields = {
-  __typename?: "circles_stddev_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
-  sub_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circles_stddev_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+  subCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "circles" */
 export type Circles_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Circles_Stddev_Samp_Fields = {
-  __typename?: "circles_stddev_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
-  sub_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circles_stddev_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+  subCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "circles" */
 export type Circles_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Circles_Sum_Fields = {
-  __typename?: "circles_sum_fields";
-  id?: Maybe<Scalars["Int"]>;
-  sub_category_id?: Maybe<Scalars["Int"]>;
+  __typename?: 'circles_sum_fields';
+  id?: Maybe<Scalars['Int']>;
+  subCategoryId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "circles" */
 export type Circles_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
 };
 
 /** update columns of table "circles" */
 export enum Circles_Update_Column {
   /** column name */
-  Avatar = "avatar",
+  Avatar = 'avatar',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  MainRole = "main_role",
+  MainRole = 'mainRole',
   /** column name */
-  Name = "name",
+  Name = 'name',
   /** column name */
-  OrganizationId = "organization_id",
+  OrganizationId = 'organizationId',
   /** column name */
-  OwnerId = "owner_id",
+  OwnerId = 'ownerId',
   /** column name */
-  RecruitTitle = "recruit_title",
+  RecruitTitle = 'recruitTitle',
   /** column name */
-  SubCategoryId = "sub_category_id",
+  SubCategoryId = 'subCategoryId',
   /** column name */
-  WhatWeWillDo = "what_we_will_do",
+  WhatWeWillDo = 'whatWeWillDo'
 }
 
 /** aggregate var_pop on columns */
 export type Circles_Var_Pop_Fields = {
-  __typename?: "circles_var_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
-  sub_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circles_var_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+  subCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "circles" */
 export type Circles_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Circles_Var_Samp_Fields = {
-  __typename?: "circles_var_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
-  sub_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circles_var_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+  subCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "circles" */
 export type Circles_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Circles_Variance_Fields = {
-  __typename?: "circles_variance_fields";
-  id?: Maybe<Scalars["Float"]>;
-  sub_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'circles_variance_fields';
+  id?: Maybe<Scalars['Float']>;
+  subCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "circles" */
 export type Circles_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  sub_category_id?: Maybe<Order_By>;
+  subCategoryId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "messages" */
 export type Messages = {
-  __typename?: "messages";
-  circle_id: Scalars["Int"];
+  __typename?: 'messages';
+  circleId: Scalars['Int'];
   /** An object relationship */
   circles: Circles;
-  id: Scalars["Int"];
-  text: Scalars["String"];
-  timestamp: Scalars["timestamptz"];
-  user_id: Scalars["String"];
+  id: Scalars['Int'];
+  text: Scalars['String'];
+  timestamp: Scalars['timestamptz'];
+  userId: Scalars['String'];
   /** An object relationship */
   users: Users;
 };
 
 /** aggregated selection of "messages" */
 export type Messages_Aggregate = {
-  __typename?: "messages_aggregate";
+  __typename?: 'messages_aggregate';
   aggregate?: Maybe<Messages_Aggregate_Fields>;
   nodes: Array<Messages>;
 };
 
 /** aggregate fields of "messages" */
 export type Messages_Aggregate_Fields = {
-  __typename?: "messages_aggregate_fields";
+  __typename?: 'messages_aggregate_fields';
   avg?: Maybe<Messages_Avg_Fields>;
-  count?: Maybe<Scalars["Int"]>;
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Messages_Max_Fields>;
   min?: Maybe<Messages_Min_Fields>;
   stddev?: Maybe<Messages_Stddev_Fields>;
@@ -1134,10 +1141,11 @@ export type Messages_Aggregate_Fields = {
   variance?: Maybe<Messages_Variance_Fields>;
 };
 
+
 /** aggregate fields of "messages" */
 export type Messages_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Messages_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "messages" */
@@ -1163,14 +1171,14 @@ export type Messages_Arr_Rel_Insert_Input = {
 
 /** aggregate avg on columns */
 export type Messages_Avg_Fields = {
-  __typename?: "messages_avg_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'messages_avg_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "messages" */
 export type Messages_Avg_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -1179,81 +1187,81 @@ export type Messages_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Messages_Bool_Exp>>>;
   _not?: Maybe<Messages_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Messages_Bool_Exp>>>;
-  circle_id?: Maybe<Int_Comparison_Exp>;
+  circleId?: Maybe<Int_Comparison_Exp>;
   circles?: Maybe<Circles_Bool_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   text?: Maybe<String_Comparison_Exp>;
   timestamp?: Maybe<Timestamptz_Comparison_Exp>;
-  user_id?: Maybe<String_Comparison_Exp>;
+  userId?: Maybe<String_Comparison_Exp>;
   users?: Maybe<Users_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "messages" */
 export enum Messages_Constraint {
   /** unique or primary key constraint */
-  MessagesPkey = "Messages_pkey",
+  MessagesPkey = 'Messages_pkey'
 }
 
 /** input type for incrementing integer column in table "messages" */
 export type Messages_Inc_Input = {
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "messages" */
 export type Messages_Insert_Input = {
-  circle_id?: Maybe<Scalars["Int"]>;
+  circleId?: Maybe<Scalars['Int']>;
   circles?: Maybe<Circles_Obj_Rel_Insert_Input>;
-  id?: Maybe<Scalars["Int"]>;
-  text?: Maybe<Scalars["String"]>;
-  timestamp?: Maybe<Scalars["timestamptz"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars['Int']>;
+  text?: Maybe<Scalars['String']>;
+  timestamp?: Maybe<Scalars['timestamptz']>;
+  userId?: Maybe<Scalars['String']>;
   users?: Maybe<Users_Obj_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
 export type Messages_Max_Fields = {
-  __typename?: "messages_max_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  text?: Maybe<Scalars["String"]>;
-  timestamp?: Maybe<Scalars["timestamptz"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  __typename?: 'messages_max_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  text?: Maybe<Scalars['String']>;
+  timestamp?: Maybe<Scalars['timestamptz']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "messages" */
 export type Messages_Max_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   timestamp?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Messages_Min_Fields = {
-  __typename?: "messages_min_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  text?: Maybe<Scalars["String"]>;
-  timestamp?: Maybe<Scalars["timestamptz"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  __typename?: 'messages_min_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  text?: Maybe<Scalars['String']>;
+  timestamp?: Maybe<Scalars['timestamptz']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "messages" */
 export type Messages_Min_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   timestamp?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "messages" */
 export type Messages_Mutation_Response = {
-  __typename?: "messages_mutation_response";
+  __typename?: 'messages_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Messages>;
 };
@@ -1273,151 +1281,151 @@ export type Messages_On_Conflict = {
 
 /** ordering options when selecting data from "messages" */
 export type Messages_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   circles?: Maybe<Circles_Order_By>;
   id?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   timestamp?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
   users?: Maybe<Users_Order_By>;
 };
 
 /** primary key columns input for table: "messages" */
 export type Messages_Pk_Columns_Input = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
 
 /** select columns of table "messages" */
 export enum Messages_Select_Column {
   /** column name */
-  CircleId = "circle_id",
+  CircleId = 'circleId',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Text = "text",
+  Text = 'text',
   /** column name */
-  Timestamp = "timestamp",
+  Timestamp = 'timestamp',
   /** column name */
-  UserId = "user_id",
+  UserId = 'userId'
 }
 
 /** input type for updating data in table "messages" */
 export type Messages_Set_Input = {
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
-  text?: Maybe<Scalars["String"]>;
-  timestamp?: Maybe<Scalars["timestamptz"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
+  text?: Maybe<Scalars['String']>;
+  timestamp?: Maybe<Scalars['timestamptz']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** aggregate stddev on columns */
 export type Messages_Stddev_Fields = {
-  __typename?: "messages_stddev_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'messages_stddev_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "messages" */
 export type Messages_Stddev_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Messages_Stddev_Pop_Fields = {
-  __typename?: "messages_stddev_pop_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'messages_stddev_pop_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "messages" */
 export type Messages_Stddev_Pop_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Messages_Stddev_Samp_Fields = {
-  __typename?: "messages_stddev_samp_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'messages_stddev_samp_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "messages" */
 export type Messages_Stddev_Samp_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Messages_Sum_Fields = {
-  __typename?: "messages_sum_fields";
-  circle_id?: Maybe<Scalars["Int"]>;
-  id?: Maybe<Scalars["Int"]>;
+  __typename?: 'messages_sum_fields';
+  circleId?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "messages" */
 export type Messages_Sum_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** update columns of table "messages" */
 export enum Messages_Update_Column {
   /** column name */
-  CircleId = "circle_id",
+  CircleId = 'circleId',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Text = "text",
+  Text = 'text',
   /** column name */
-  Timestamp = "timestamp",
+  Timestamp = 'timestamp',
   /** column name */
-  UserId = "user_id",
+  UserId = 'userId'
 }
 
 /** aggregate var_pop on columns */
 export type Messages_Var_Pop_Fields = {
-  __typename?: "messages_var_pop_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'messages_var_pop_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "messages" */
 export type Messages_Var_Pop_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Messages_Var_Samp_Fields = {
-  __typename?: "messages_var_samp_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'messages_var_samp_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "messages" */
 export type Messages_Var_Samp_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Messages_Variance_Fields = {
-  __typename?: "messages_variance_fields";
-  circle_id?: Maybe<Scalars["Float"]>;
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'messages_variance_fields';
+  circleId?: Maybe<Scalars['Float']>;
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "messages" */
 export type Messages_Variance_Order_By = {
-  circle_id?: Maybe<Order_By>;
+  circleId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** mutation root */
 export type Mutation_Root = {
-  __typename?: "mutation_root";
+  __typename?: 'mutation_root';
   /** delete data from the table: "circle_skills" */
   delete_circle_skills?: Maybe<Circle_Skills_Mutation_Response>;
   /** delete single row from the table: "circle_skills" */
@@ -1540,105 +1548,126 @@ export type Mutation_Root = {
   update_users_by_pk?: Maybe<Users>;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Circle_SkillsArgs = {
   where: Circle_Skills_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Circle_Skills_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_Circle_UsersArgs = {
   where: Circle_Users_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Circle_Users_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_CirclesArgs = {
   where: Circles_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Circles_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_MessagesArgs = {
   where: Messages_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Messages_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_OrganizationsArgs = {
   where: Organizations_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Organizations_By_PkArgs = {
-  id: Scalars["String"];
+  id: Scalars['String'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_Parent_CategoriesArgs = {
   where: Parent_Categories_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Parent_Categories_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_SkillsArgs = {
   where: Skills_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Skills_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_Sub_CategoriesArgs = {
   where: Sub_Categories_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Sub_Categories_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_User_SkillsArgs = {
   where: User_Skills_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_User_Skills_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** mutation root */
 export type Mutation_RootDelete_UsersArgs = {
   where: Users_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootDelete_Users_By_PkArgs = {
-  id: Scalars["String"];
+  id: Scalars['String'];
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_Circle_SkillsArgs = {
@@ -1646,11 +1675,13 @@ export type Mutation_RootInsert_Circle_SkillsArgs = {
   on_conflict?: Maybe<Circle_Skills_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Circle_Skills_OneArgs = {
   object: Circle_Skills_Insert_Input;
   on_conflict?: Maybe<Circle_Skills_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_Circle_UsersArgs = {
@@ -1658,11 +1689,13 @@ export type Mutation_RootInsert_Circle_UsersArgs = {
   on_conflict?: Maybe<Circle_Users_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Circle_Users_OneArgs = {
   object: Circle_Users_Insert_Input;
   on_conflict?: Maybe<Circle_Users_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_CirclesArgs = {
@@ -1670,11 +1703,13 @@ export type Mutation_RootInsert_CirclesArgs = {
   on_conflict?: Maybe<Circles_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Circles_OneArgs = {
   object: Circles_Insert_Input;
   on_conflict?: Maybe<Circles_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_MessagesArgs = {
@@ -1682,11 +1717,13 @@ export type Mutation_RootInsert_MessagesArgs = {
   on_conflict?: Maybe<Messages_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Messages_OneArgs = {
   object: Messages_Insert_Input;
   on_conflict?: Maybe<Messages_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_OrganizationsArgs = {
@@ -1694,11 +1731,13 @@ export type Mutation_RootInsert_OrganizationsArgs = {
   on_conflict?: Maybe<Organizations_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Organizations_OneArgs = {
   object: Organizations_Insert_Input;
   on_conflict?: Maybe<Organizations_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_Parent_CategoriesArgs = {
@@ -1706,11 +1745,13 @@ export type Mutation_RootInsert_Parent_CategoriesArgs = {
   on_conflict?: Maybe<Parent_Categories_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Parent_Categories_OneArgs = {
   object: Parent_Categories_Insert_Input;
   on_conflict?: Maybe<Parent_Categories_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_SkillsArgs = {
@@ -1718,11 +1759,13 @@ export type Mutation_RootInsert_SkillsArgs = {
   on_conflict?: Maybe<Skills_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Skills_OneArgs = {
   object: Skills_Insert_Input;
   on_conflict?: Maybe<Skills_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_Sub_CategoriesArgs = {
@@ -1730,11 +1773,13 @@ export type Mutation_RootInsert_Sub_CategoriesArgs = {
   on_conflict?: Maybe<Sub_Categories_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Sub_Categories_OneArgs = {
   object: Sub_Categories_Insert_Input;
   on_conflict?: Maybe<Sub_Categories_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_User_SkillsArgs = {
@@ -1742,11 +1787,13 @@ export type Mutation_RootInsert_User_SkillsArgs = {
   on_conflict?: Maybe<User_Skills_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_User_Skills_OneArgs = {
   object: User_Skills_Insert_Input;
   on_conflict?: Maybe<User_Skills_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootInsert_UsersArgs = {
@@ -1754,11 +1801,13 @@ export type Mutation_RootInsert_UsersArgs = {
   on_conflict?: Maybe<Users_On_Conflict>;
 };
 
+
 /** mutation root */
 export type Mutation_RootInsert_Users_OneArgs = {
   object: Users_Insert_Input;
   on_conflict?: Maybe<Users_On_Conflict>;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_Circle_SkillsArgs = {
@@ -1767,12 +1816,14 @@ export type Mutation_RootUpdate_Circle_SkillsArgs = {
   where: Circle_Skills_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Circle_Skills_By_PkArgs = {
   _inc?: Maybe<Circle_Skills_Inc_Input>;
   _set?: Maybe<Circle_Skills_Set_Input>;
   pk_columns: Circle_Skills_Pk_Columns_Input;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_Circle_UsersArgs = {
@@ -1781,12 +1832,14 @@ export type Mutation_RootUpdate_Circle_UsersArgs = {
   where: Circle_Users_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Circle_Users_By_PkArgs = {
   _inc?: Maybe<Circle_Users_Inc_Input>;
   _set?: Maybe<Circle_Users_Set_Input>;
   pk_columns: Circle_Users_Pk_Columns_Input;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_CirclesArgs = {
@@ -1795,12 +1848,14 @@ export type Mutation_RootUpdate_CirclesArgs = {
   where: Circles_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Circles_By_PkArgs = {
   _inc?: Maybe<Circles_Inc_Input>;
   _set?: Maybe<Circles_Set_Input>;
   pk_columns: Circles_Pk_Columns_Input;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_MessagesArgs = {
@@ -1809,6 +1864,7 @@ export type Mutation_RootUpdate_MessagesArgs = {
   where: Messages_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Messages_By_PkArgs = {
   _inc?: Maybe<Messages_Inc_Input>;
@@ -1816,17 +1872,20 @@ export type Mutation_RootUpdate_Messages_By_PkArgs = {
   pk_columns: Messages_Pk_Columns_Input;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_OrganizationsArgs = {
   _set?: Maybe<Organizations_Set_Input>;
   where: Organizations_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Organizations_By_PkArgs = {
   _set?: Maybe<Organizations_Set_Input>;
   pk_columns: Organizations_Pk_Columns_Input;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_Parent_CategoriesArgs = {
@@ -1835,12 +1894,14 @@ export type Mutation_RootUpdate_Parent_CategoriesArgs = {
   where: Parent_Categories_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Parent_Categories_By_PkArgs = {
   _inc?: Maybe<Parent_Categories_Inc_Input>;
   _set?: Maybe<Parent_Categories_Set_Input>;
   pk_columns: Parent_Categories_Pk_Columns_Input;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_SkillsArgs = {
@@ -1849,12 +1910,14 @@ export type Mutation_RootUpdate_SkillsArgs = {
   where: Skills_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Skills_By_PkArgs = {
   _inc?: Maybe<Skills_Inc_Input>;
   _set?: Maybe<Skills_Set_Input>;
   pk_columns: Skills_Pk_Columns_Input;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_Sub_CategoriesArgs = {
@@ -1863,12 +1926,14 @@ export type Mutation_RootUpdate_Sub_CategoriesArgs = {
   where: Sub_Categories_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_Sub_Categories_By_PkArgs = {
   _inc?: Maybe<Sub_Categories_Inc_Input>;
   _set?: Maybe<Sub_Categories_Set_Input>;
   pk_columns: Sub_Categories_Pk_Columns_Input;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_User_SkillsArgs = {
@@ -1877,6 +1942,7 @@ export type Mutation_RootUpdate_User_SkillsArgs = {
   where: User_Skills_Bool_Exp;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_User_Skills_By_PkArgs = {
   _inc?: Maybe<User_Skills_Inc_Input>;
@@ -1884,11 +1950,13 @@ export type Mutation_RootUpdate_User_Skills_By_PkArgs = {
   pk_columns: User_Skills_Pk_Columns_Input;
 };
 
+
 /** mutation root */
 export type Mutation_RootUpdate_UsersArgs = {
   _set?: Maybe<Users_Set_Input>;
   where: Users_Bool_Exp;
 };
+
 
 /** mutation root */
 export type Mutation_RootUpdate_Users_By_PkArgs = {
@@ -1899,89 +1967,94 @@ export type Mutation_RootUpdate_Users_By_PkArgs = {
 /** column ordering options */
 export enum Order_By {
   /** in the ascending order, nulls last */
-  Asc = "asc",
+  Asc = 'asc',
   /** in the ascending order, nulls first */
-  AscNullsFirst = "asc_nulls_first",
+  AscNullsFirst = 'asc_nulls_first',
   /** in the ascending order, nulls last */
-  AscNullsLast = "asc_nulls_last",
+  AscNullsLast = 'asc_nulls_last',
   /** in the descending order, nulls first */
-  Desc = "desc",
+  Desc = 'desc',
   /** in the descending order, nulls first */
-  DescNullsFirst = "desc_nulls_first",
+  DescNullsFirst = 'desc_nulls_first',
   /** in the descending order, nulls last */
-  DescNullsLast = "desc_nulls_last",
+  DescNullsLast = 'desc_nulls_last'
 }
 
 /** columns and relationships of "organizations" */
 export type Organizations = {
-  __typename?: "organizations";
+  __typename?: 'organizations';
   /** An array relationship */
   circles: Array<Circles>;
   /** An aggregated array relationship */
   circles_aggregate: Circles_Aggregate;
-  id: Scalars["String"];
-  name: Scalars["String"];
+  id: Scalars['String'];
+  name: Scalars['String'];
   /** An array relationship */
   users: Array<Users>;
   /** An aggregated array relationship */
   users_aggregate: Users_Aggregate;
 };
 
+
 /** columns and relationships of "organizations" */
 export type OrganizationsCirclesArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
+
 
 /** columns and relationships of "organizations" */
 export type OrganizationsCircles_AggregateArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
 
+
 /** columns and relationships of "organizations" */
 export type OrganizationsUsersArgs = {
   distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Users_Order_By>>;
   where?: Maybe<Users_Bool_Exp>;
 };
 
+
 /** columns and relationships of "organizations" */
 export type OrganizationsUsers_AggregateArgs = {
   distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Users_Order_By>>;
   where?: Maybe<Users_Bool_Exp>;
 };
 
 /** aggregated selection of "organizations" */
 export type Organizations_Aggregate = {
-  __typename?: "organizations_aggregate";
+  __typename?: 'organizations_aggregate';
   aggregate?: Maybe<Organizations_Aggregate_Fields>;
   nodes: Array<Organizations>;
 };
 
 /** aggregate fields of "organizations" */
 export type Organizations_Aggregate_Fields = {
-  __typename?: "organizations_aggregate_fields";
-  count?: Maybe<Scalars["Int"]>;
+  __typename?: 'organizations_aggregate_fields';
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Organizations_Max_Fields>;
   min?: Maybe<Organizations_Min_Fields>;
 };
 
+
 /** aggregate fields of "organizations" */
 export type Organizations_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Organizations_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "organizations" */
@@ -2011,22 +2084,22 @@ export type Organizations_Bool_Exp = {
 /** unique or primary key constraints on table "organizations" */
 export enum Organizations_Constraint {
   /** unique or primary key constraint */
-  OrganizationPkey = "Organization_pkey",
+  OrganizationPkey = 'Organization_pkey'
 }
 
 /** input type for inserting data into table "organizations" */
 export type Organizations_Insert_Input = {
   circles?: Maybe<Circles_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
   users?: Maybe<Users_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
 export type Organizations_Max_Fields = {
-  __typename?: "organizations_max_fields";
-  id?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
+  __typename?: 'organizations_max_fields';
+  id?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "organizations" */
@@ -2037,9 +2110,9 @@ export type Organizations_Max_Order_By = {
 
 /** aggregate min on columns */
 export type Organizations_Min_Fields = {
-  __typename?: "organizations_min_fields";
-  id?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
+  __typename?: 'organizations_min_fields';
+  id?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "organizations" */
@@ -2050,9 +2123,9 @@ export type Organizations_Min_Order_By = {
 
 /** response of any mutation on the table "organizations" */
 export type Organizations_Mutation_Response = {
-  __typename?: "organizations_mutation_response";
+  __typename?: 'organizations_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Organizations>;
 };
@@ -2080,72 +2153,74 @@ export type Organizations_Order_By = {
 
 /** primary key columns input for table: "organizations" */
 export type Organizations_Pk_Columns_Input = {
-  id: Scalars["String"];
+  id: Scalars['String'];
 };
 
 /** select columns of table "organizations" */
 export enum Organizations_Select_Column {
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Name = "name",
+  Name = 'name'
 }
 
 /** input type for updating data in table "organizations" */
 export type Organizations_Set_Input = {
-  id?: Maybe<Scalars["String"]>;
-  name?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** update columns of table "organizations" */
 export enum Organizations_Update_Column {
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Name = "name",
+  Name = 'name'
 }
 
 /** columns and relationships of "parent_categories" */
 export type Parent_Categories = {
-  __typename?: "parent_categories";
-  id: Scalars["Int"];
-  name: Scalars["String"];
+  __typename?: 'parent_categories';
+  id: Scalars['Int'];
+  name: Scalars['String'];
   /** An array relationship */
-  sub_categories: Array<Sub_Categories>;
+  subCategories: Array<Sub_Categories>;
   /** An aggregated array relationship */
-  sub_categories_aggregate: Sub_Categories_Aggregate;
+  subCategories_aggregate: Sub_Categories_Aggregate;
 };
 
+
 /** columns and relationships of "parent_categories" */
-export type Parent_CategoriesSub_CategoriesArgs = {
+export type Parent_CategoriesSubCategoriesArgs = {
   distinct_on?: Maybe<Array<Sub_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Sub_Categories_Order_By>>;
   where?: Maybe<Sub_Categories_Bool_Exp>;
 };
 
+
 /** columns and relationships of "parent_categories" */
-export type Parent_CategoriesSub_Categories_AggregateArgs = {
+export type Parent_CategoriesSubCategories_AggregateArgs = {
   distinct_on?: Maybe<Array<Sub_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Sub_Categories_Order_By>>;
   where?: Maybe<Sub_Categories_Bool_Exp>;
 };
 
 /** aggregated selection of "parent_categories" */
 export type Parent_Categories_Aggregate = {
-  __typename?: "parent_categories_aggregate";
+  __typename?: 'parent_categories_aggregate';
   aggregate?: Maybe<Parent_Categories_Aggregate_Fields>;
   nodes: Array<Parent_Categories>;
 };
 
 /** aggregate fields of "parent_categories" */
 export type Parent_Categories_Aggregate_Fields = {
-  __typename?: "parent_categories_aggregate_fields";
+  __typename?: 'parent_categories_aggregate_fields';
   avg?: Maybe<Parent_Categories_Avg_Fields>;
-  count?: Maybe<Scalars["Int"]>;
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Parent_Categories_Max_Fields>;
   min?: Maybe<Parent_Categories_Min_Fields>;
   stddev?: Maybe<Parent_Categories_Stddev_Fields>;
@@ -2157,10 +2232,11 @@ export type Parent_Categories_Aggregate_Fields = {
   variance?: Maybe<Parent_Categories_Variance_Fields>;
 };
 
+
 /** aggregate fields of "parent_categories" */
 export type Parent_Categories_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Parent_Categories_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "parent_categories" */
@@ -2186,8 +2262,8 @@ export type Parent_Categories_Arr_Rel_Insert_Input = {
 
 /** aggregate avg on columns */
 export type Parent_Categories_Avg_Fields = {
-  __typename?: "parent_categories_avg_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'parent_categories_avg_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "parent_categories" */
@@ -2202,32 +2278,32 @@ export type Parent_Categories_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Parent_Categories_Bool_Exp>>>;
   id?: Maybe<Int_Comparison_Exp>;
   name?: Maybe<String_Comparison_Exp>;
-  sub_categories?: Maybe<Sub_Categories_Bool_Exp>;
+  subCategories?: Maybe<Sub_Categories_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "parent_categories" */
 export enum Parent_Categories_Constraint {
   /** unique or primary key constraint */
-  ParentCategoryPkey = "ParentCategory_pkey",
+  ParentCategoryPkey = 'ParentCategory_pkey'
 }
 
 /** input type for incrementing integer column in table "parent_categories" */
 export type Parent_Categories_Inc_Input = {
-  id?: Maybe<Scalars["Int"]>;
+  id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "parent_categories" */
 export type Parent_Categories_Insert_Input = {
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
-  sub_categories?: Maybe<Sub_Categories_Arr_Rel_Insert_Input>;
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
+  subCategories?: Maybe<Sub_Categories_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
 export type Parent_Categories_Max_Fields = {
-  __typename?: "parent_categories_max_fields";
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
+  __typename?: 'parent_categories_max_fields';
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "parent_categories" */
@@ -2238,9 +2314,9 @@ export type Parent_Categories_Max_Order_By = {
 
 /** aggregate min on columns */
 export type Parent_Categories_Min_Fields = {
-  __typename?: "parent_categories_min_fields";
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
+  __typename?: 'parent_categories_min_fields';
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "parent_categories" */
@@ -2251,9 +2327,9 @@ export type Parent_Categories_Min_Order_By = {
 
 /** response of any mutation on the table "parent_categories" */
 export type Parent_Categories_Mutation_Response = {
-  __typename?: "parent_categories_mutation_response";
+  __typename?: 'parent_categories_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Parent_Categories>;
 };
@@ -2275,32 +2351,32 @@ export type Parent_Categories_On_Conflict = {
 export type Parent_Categories_Order_By = {
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  sub_categories_aggregate?: Maybe<Sub_Categories_Aggregate_Order_By>;
+  subCategories_aggregate?: Maybe<Sub_Categories_Aggregate_Order_By>;
 };
 
 /** primary key columns input for table: "parent_categories" */
 export type Parent_Categories_Pk_Columns_Input = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
 
 /** select columns of table "parent_categories" */
 export enum Parent_Categories_Select_Column {
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Name = "name",
+  Name = 'name'
 }
 
 /** input type for updating data in table "parent_categories" */
 export type Parent_Categories_Set_Input = {
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** aggregate stddev on columns */
 export type Parent_Categories_Stddev_Fields = {
-  __typename?: "parent_categories_stddev_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'parent_categories_stddev_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "parent_categories" */
@@ -2310,8 +2386,8 @@ export type Parent_Categories_Stddev_Order_By = {
 
 /** aggregate stddev_pop on columns */
 export type Parent_Categories_Stddev_Pop_Fields = {
-  __typename?: "parent_categories_stddev_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'parent_categories_stddev_pop_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "parent_categories" */
@@ -2321,8 +2397,8 @@ export type Parent_Categories_Stddev_Pop_Order_By = {
 
 /** aggregate stddev_samp on columns */
 export type Parent_Categories_Stddev_Samp_Fields = {
-  __typename?: "parent_categories_stddev_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'parent_categories_stddev_samp_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "parent_categories" */
@@ -2332,8 +2408,8 @@ export type Parent_Categories_Stddev_Samp_Order_By = {
 
 /** aggregate sum on columns */
 export type Parent_Categories_Sum_Fields = {
-  __typename?: "parent_categories_sum_fields";
-  id?: Maybe<Scalars["Int"]>;
+  __typename?: 'parent_categories_sum_fields';
+  id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "parent_categories" */
@@ -2344,15 +2420,15 @@ export type Parent_Categories_Sum_Order_By = {
 /** update columns of table "parent_categories" */
 export enum Parent_Categories_Update_Column {
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Name = "name",
+  Name = 'name'
 }
 
 /** aggregate var_pop on columns */
 export type Parent_Categories_Var_Pop_Fields = {
-  __typename?: "parent_categories_var_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'parent_categories_var_pop_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "parent_categories" */
@@ -2362,8 +2438,8 @@ export type Parent_Categories_Var_Pop_Order_By = {
 
 /** aggregate var_samp on columns */
 export type Parent_Categories_Var_Samp_Fields = {
-  __typename?: "parent_categories_var_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'parent_categories_var_samp_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "parent_categories" */
@@ -2373,8 +2449,8 @@ export type Parent_Categories_Var_Samp_Order_By = {
 
 /** aggregate variance on columns */
 export type Parent_Categories_Variance_Fields = {
-  __typename?: "parent_categories_variance_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'parent_categories_variance_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "parent_categories" */
@@ -2384,15 +2460,15 @@ export type Parent_Categories_Variance_Order_By = {
 
 /** query root */
 export type Query_Root = {
-  __typename?: "query_root";
+  __typename?: 'query_root';
   /** fetch data from the table: "circle_skills" */
-  circle_skills: Array<Circle_Skills>;
+  circleSkills: Array<Circle_Skills>;
+  /** fetch data from the table: "circle_users" */
+  circleUsers: Array<Circle_Users>;
   /** fetch aggregated fields from the table: "circle_skills" */
   circle_skills_aggregate: Circle_Skills_Aggregate;
   /** fetch data from the table: "circle_skills" using primary key columns */
   circle_skills_by_pk?: Maybe<Circle_Skills>;
-  /** fetch data from the table: "circle_users" */
-  circle_users: Array<Circle_Users>;
   /** fetch aggregated fields from the table: "circle_users" */
   circle_users_aggregate: Circle_Users_Aggregate;
   /** fetch data from the table: "circle_users" using primary key columns */
@@ -2416,7 +2492,7 @@ export type Query_Root = {
   /** fetch data from the table: "organizations" using primary key columns */
   organizations_by_pk?: Maybe<Organizations>;
   /** fetch data from the table: "parent_categories" */
-  parent_categories: Array<Parent_Categories>;
+  parentCategories: Array<Parent_Categories>;
   /** fetch aggregated fields from the table: "parent_categories" */
   parent_categories_aggregate: Parent_Categories_Aggregate;
   /** fetch data from the table: "parent_categories" using primary key columns */
@@ -2428,13 +2504,13 @@ export type Query_Root = {
   /** fetch data from the table: "skills" using primary key columns */
   skills_by_pk?: Maybe<Skills>;
   /** fetch data from the table: "sub_categories" */
-  sub_categories: Array<Sub_Categories>;
+  subCategories: Array<Sub_Categories>;
+  /** fetch data from the table: "sub_categories" using primary key columns */
+  subCategory?: Maybe<Sub_Categories>;
   /** fetch aggregated fields from the table: "sub_categories" */
   sub_categories_aggregate: Sub_Categories_Aggregate;
-  /** fetch data from the table: "sub_categories" using primary key columns */
-  sub_categories_by_pk?: Maybe<Sub_Categories>;
   /** fetch data from the table: "user_skills" */
-  user_skills: Array<User_Skills>;
+  userSkills: Array<User_Skills>;
   /** fetch aggregated fields from the table: "user_skills" */
   user_skills_aggregate: User_Skills_Aggregate;
   /** fetch data from the table: "user_skills" using primary key columns */
@@ -2447,300 +2523,334 @@ export type Query_Root = {
   users_by_pk?: Maybe<Users>;
 };
 
+
 /** query root */
-export type Query_RootCircle_SkillsArgs = {
+export type Query_RootCircleSkillsArgs = {
   distinct_on?: Maybe<Array<Circle_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Skills_Order_By>>;
   where?: Maybe<Circle_Skills_Bool_Exp>;
 };
+
+
+/** query root */
+export type Query_RootCircleUsersArgs = {
+  distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Circle_Users_Order_By>>;
+  where?: Maybe<Circle_Users_Bool_Exp>;
+};
+
 
 /** query root */
 export type Query_RootCircle_Skills_AggregateArgs = {
   distinct_on?: Maybe<Array<Circle_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Skills_Order_By>>;
   where?: Maybe<Circle_Skills_Bool_Exp>;
 };
 
-/** query root */
-export type Query_RootCircle_Skills_By_PkArgs = {
-  id: Scalars["Int"];
-};
 
 /** query root */
-export type Query_RootCircle_UsersArgs = {
-  distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
-  order_by?: Maybe<Array<Circle_Users_Order_By>>;
-  where?: Maybe<Circle_Users_Bool_Exp>;
+export type Query_RootCircle_Skills_By_PkArgs = {
+  id: Scalars['Int'];
 };
+
 
 /** query root */
 export type Query_RootCircle_Users_AggregateArgs = {
   distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Users_Order_By>>;
   where?: Maybe<Circle_Users_Bool_Exp>;
 };
 
+
 /** query root */
 export type Query_RootCircle_Users_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** query root */
 export type Query_RootCirclesArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
+
 
 /** query root */
 export type Query_RootCircles_AggregateArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
 
+
 /** query root */
 export type Query_RootCircles_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** query root */
 export type Query_RootMessagesArgs = {
   distinct_on?: Maybe<Array<Messages_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Messages_Order_By>>;
   where?: Maybe<Messages_Bool_Exp>;
 };
+
 
 /** query root */
 export type Query_RootMessages_AggregateArgs = {
   distinct_on?: Maybe<Array<Messages_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Messages_Order_By>>;
   where?: Maybe<Messages_Bool_Exp>;
 };
 
+
 /** query root */
 export type Query_RootMessages_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** query root */
 export type Query_RootOrganizationsArgs = {
   distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Organizations_Order_By>>;
   where?: Maybe<Organizations_Bool_Exp>;
 };
+
 
 /** query root */
 export type Query_RootOrganizations_AggregateArgs = {
   distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Organizations_Order_By>>;
   where?: Maybe<Organizations_Bool_Exp>;
 };
 
-/** query root */
-export type Query_RootOrganizations_By_PkArgs = {
-  id: Scalars["String"];
-};
 
 /** query root */
-export type Query_RootParent_CategoriesArgs = {
+export type Query_RootOrganizations_By_PkArgs = {
+  id: Scalars['String'];
+};
+
+
+/** query root */
+export type Query_RootParentCategoriesArgs = {
   distinct_on?: Maybe<Array<Parent_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Parent_Categories_Order_By>>;
   where?: Maybe<Parent_Categories_Bool_Exp>;
 };
+
 
 /** query root */
 export type Query_RootParent_Categories_AggregateArgs = {
   distinct_on?: Maybe<Array<Parent_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Parent_Categories_Order_By>>;
   where?: Maybe<Parent_Categories_Bool_Exp>;
 };
 
+
 /** query root */
 export type Query_RootParent_Categories_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** query root */
 export type Query_RootSkillsArgs = {
   distinct_on?: Maybe<Array<Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Skills_Order_By>>;
   where?: Maybe<Skills_Bool_Exp>;
 };
+
 
 /** query root */
 export type Query_RootSkills_AggregateArgs = {
   distinct_on?: Maybe<Array<Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Skills_Order_By>>;
   where?: Maybe<Skills_Bool_Exp>;
 };
 
-/** query root */
-export type Query_RootSkills_By_PkArgs = {
-  id: Scalars["Int"];
-};
 
 /** query root */
-export type Query_RootSub_CategoriesArgs = {
+export type Query_RootSkills_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** query root */
+export type Query_RootSubCategoriesArgs = {
   distinct_on?: Maybe<Array<Sub_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Sub_Categories_Order_By>>;
   where?: Maybe<Sub_Categories_Bool_Exp>;
 };
+
+
+/** query root */
+export type Query_RootSubCategoryArgs = {
+  id: Scalars['Int'];
+};
+
 
 /** query root */
 export type Query_RootSub_Categories_AggregateArgs = {
   distinct_on?: Maybe<Array<Sub_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Sub_Categories_Order_By>>;
   where?: Maybe<Sub_Categories_Bool_Exp>;
 };
 
-/** query root */
-export type Query_RootSub_Categories_By_PkArgs = {
-  id: Scalars["Int"];
-};
 
 /** query root */
-export type Query_RootUser_SkillsArgs = {
+export type Query_RootUserSkillsArgs = {
   distinct_on?: Maybe<Array<User_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<User_Skills_Order_By>>;
   where?: Maybe<User_Skills_Bool_Exp>;
 };
+
 
 /** query root */
 export type Query_RootUser_Skills_AggregateArgs = {
   distinct_on?: Maybe<Array<User_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<User_Skills_Order_By>>;
   where?: Maybe<User_Skills_Bool_Exp>;
 };
 
+
 /** query root */
 export type Query_RootUser_Skills_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** query root */
 export type Query_RootUsersArgs = {
   distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Users_Order_By>>;
   where?: Maybe<Users_Bool_Exp>;
 };
+
 
 /** query root */
 export type Query_RootUsers_AggregateArgs = {
   distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Users_Order_By>>;
   where?: Maybe<Users_Bool_Exp>;
 };
 
+
 /** query root */
 export type Query_RootUsers_By_PkArgs = {
-  id: Scalars["String"];
+  id: Scalars['String'];
 };
 
 /** columns and relationships of "skills" */
 export type Skills = {
-  __typename?: "skills";
-  avatar: Scalars["String"];
+  __typename?: 'skills';
+  avatar: Scalars['String'];
   /** An array relationship */
-  circle_skills: Array<Circle_Skills>;
+  circleSkills: Array<Circle_Skills>;
   /** An aggregated array relationship */
-  circle_skills_aggregate: Circle_Skills_Aggregate;
-  id: Scalars["Int"];
-  name: Scalars["String"];
+  circleSkills_aggregate: Circle_Skills_Aggregate;
+  id: Scalars['Int'];
+  name: Scalars['String'];
   /** An array relationship */
-  user_skills: Array<User_Skills>;
+  userSkills: Array<User_Skills>;
   /** An aggregated array relationship */
-  user_skills_aggregate: User_Skills_Aggregate;
+  userSkills_aggregate: User_Skills_Aggregate;
 };
 
+
 /** columns and relationships of "skills" */
-export type SkillsCircle_SkillsArgs = {
+export type SkillsCircleSkillsArgs = {
   distinct_on?: Maybe<Array<Circle_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Skills_Order_By>>;
   where?: Maybe<Circle_Skills_Bool_Exp>;
 };
 
+
 /** columns and relationships of "skills" */
-export type SkillsCircle_Skills_AggregateArgs = {
+export type SkillsCircleSkills_AggregateArgs = {
   distinct_on?: Maybe<Array<Circle_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Skills_Order_By>>;
   where?: Maybe<Circle_Skills_Bool_Exp>;
 };
 
+
 /** columns and relationships of "skills" */
-export type SkillsUser_SkillsArgs = {
+export type SkillsUserSkillsArgs = {
   distinct_on?: Maybe<Array<User_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<User_Skills_Order_By>>;
   where?: Maybe<User_Skills_Bool_Exp>;
 };
 
+
 /** columns and relationships of "skills" */
-export type SkillsUser_Skills_AggregateArgs = {
+export type SkillsUserSkills_AggregateArgs = {
   distinct_on?: Maybe<Array<User_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<User_Skills_Order_By>>;
   where?: Maybe<User_Skills_Bool_Exp>;
 };
 
 /** aggregated selection of "skills" */
 export type Skills_Aggregate = {
-  __typename?: "skills_aggregate";
+  __typename?: 'skills_aggregate';
   aggregate?: Maybe<Skills_Aggregate_Fields>;
   nodes: Array<Skills>;
 };
 
 /** aggregate fields of "skills" */
 export type Skills_Aggregate_Fields = {
-  __typename?: "skills_aggregate_fields";
+  __typename?: 'skills_aggregate_fields';
   avg?: Maybe<Skills_Avg_Fields>;
-  count?: Maybe<Scalars["Int"]>;
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Skills_Max_Fields>;
   min?: Maybe<Skills_Min_Fields>;
   stddev?: Maybe<Skills_Stddev_Fields>;
@@ -2752,10 +2862,11 @@ export type Skills_Aggregate_Fields = {
   variance?: Maybe<Skills_Variance_Fields>;
 };
 
+
 /** aggregate fields of "skills" */
 export type Skills_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Skills_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "skills" */
@@ -2781,8 +2892,8 @@ export type Skills_Arr_Rel_Insert_Input = {
 
 /** aggregate avg on columns */
 export type Skills_Avg_Fields = {
-  __typename?: "skills_avg_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'skills_avg_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "skills" */
@@ -2796,38 +2907,38 @@ export type Skills_Bool_Exp = {
   _not?: Maybe<Skills_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Skills_Bool_Exp>>>;
   avatar?: Maybe<String_Comparison_Exp>;
-  circle_skills?: Maybe<Circle_Skills_Bool_Exp>;
+  circleSkills?: Maybe<Circle_Skills_Bool_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   name?: Maybe<String_Comparison_Exp>;
-  user_skills?: Maybe<User_Skills_Bool_Exp>;
+  userSkills?: Maybe<User_Skills_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "skills" */
 export enum Skills_Constraint {
   /** unique or primary key constraint */
-  SkillPkey = "Skill_pkey",
+  SkillPkey = 'Skill_pkey'
 }
 
 /** input type for incrementing integer column in table "skills" */
 export type Skills_Inc_Input = {
-  id?: Maybe<Scalars["Int"]>;
+  id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "skills" */
 export type Skills_Insert_Input = {
-  avatar?: Maybe<Scalars["String"]>;
-  circle_skills?: Maybe<Circle_Skills_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
-  user_skills?: Maybe<User_Skills_Arr_Rel_Insert_Input>;
+  avatar?: Maybe<Scalars['String']>;
+  circleSkills?: Maybe<Circle_Skills_Arr_Rel_Insert_Input>;
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
+  userSkills?: Maybe<User_Skills_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
 export type Skills_Max_Fields = {
-  __typename?: "skills_max_fields";
-  avatar?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
+  __typename?: 'skills_max_fields';
+  avatar?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "skills" */
@@ -2839,10 +2950,10 @@ export type Skills_Max_Order_By = {
 
 /** aggregate min on columns */
 export type Skills_Min_Fields = {
-  __typename?: "skills_min_fields";
-  avatar?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
+  __typename?: 'skills_min_fields';
+  avatar?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "skills" */
@@ -2854,9 +2965,9 @@ export type Skills_Min_Order_By = {
 
 /** response of any mutation on the table "skills" */
 export type Skills_Mutation_Response = {
-  __typename?: "skills_mutation_response";
+  __typename?: 'skills_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Skills>;
 };
@@ -2877,38 +2988,38 @@ export type Skills_On_Conflict = {
 /** ordering options when selecting data from "skills" */
 export type Skills_Order_By = {
   avatar?: Maybe<Order_By>;
-  circle_skills_aggregate?: Maybe<Circle_Skills_Aggregate_Order_By>;
+  circleSkills_aggregate?: Maybe<Circle_Skills_Aggregate_Order_By>;
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  user_skills_aggregate?: Maybe<User_Skills_Aggregate_Order_By>;
+  userSkills_aggregate?: Maybe<User_Skills_Aggregate_Order_By>;
 };
 
 /** primary key columns input for table: "skills" */
 export type Skills_Pk_Columns_Input = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
 
 /** select columns of table "skills" */
 export enum Skills_Select_Column {
   /** column name */
-  Avatar = "avatar",
+  Avatar = 'avatar',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Name = "name",
+  Name = 'name'
 }
 
 /** input type for updating data in table "skills" */
 export type Skills_Set_Input = {
-  avatar?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
+  avatar?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 /** aggregate stddev on columns */
 export type Skills_Stddev_Fields = {
-  __typename?: "skills_stddev_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'skills_stddev_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "skills" */
@@ -2918,8 +3029,8 @@ export type Skills_Stddev_Order_By = {
 
 /** aggregate stddev_pop on columns */
 export type Skills_Stddev_Pop_Fields = {
-  __typename?: "skills_stddev_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'skills_stddev_pop_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "skills" */
@@ -2929,8 +3040,8 @@ export type Skills_Stddev_Pop_Order_By = {
 
 /** aggregate stddev_samp on columns */
 export type Skills_Stddev_Samp_Fields = {
-  __typename?: "skills_stddev_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'skills_stddev_samp_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "skills" */
@@ -2940,8 +3051,8 @@ export type Skills_Stddev_Samp_Order_By = {
 
 /** aggregate sum on columns */
 export type Skills_Sum_Fields = {
-  __typename?: "skills_sum_fields";
-  id?: Maybe<Scalars["Int"]>;
+  __typename?: 'skills_sum_fields';
+  id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "skills" */
@@ -2952,17 +3063,17 @@ export type Skills_Sum_Order_By = {
 /** update columns of table "skills" */
 export enum Skills_Update_Column {
   /** column name */
-  Avatar = "avatar",
+  Avatar = 'avatar',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Name = "name",
+  Name = 'name'
 }
 
 /** aggregate var_pop on columns */
 export type Skills_Var_Pop_Fields = {
-  __typename?: "skills_var_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'skills_var_pop_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "skills" */
@@ -2972,8 +3083,8 @@ export type Skills_Var_Pop_Order_By = {
 
 /** aggregate var_samp on columns */
 export type Skills_Var_Samp_Fields = {
-  __typename?: "skills_var_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'skills_var_samp_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "skills" */
@@ -2983,8 +3094,8 @@ export type Skills_Var_Samp_Order_By = {
 
 /** aggregate variance on columns */
 export type Skills_Variance_Fields = {
-  __typename?: "skills_variance_fields";
-  id?: Maybe<Scalars["Float"]>;
+  __typename?: 'skills_variance_fields';
+  id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "skills" */
@@ -2994,50 +3105,52 @@ export type Skills_Variance_Order_By = {
 
 /** columns and relationships of "sub_categories" */
 export type Sub_Categories = {
-  __typename?: "sub_categories";
+  __typename?: 'sub_categories';
   /** An array relationship */
   circles: Array<Circles>;
   /** An aggregated array relationship */
   circles_aggregate: Circles_Aggregate;
-  id: Scalars["Int"];
-  name: Scalars["String"];
+  id: Scalars['Int'];
+  name: Scalars['String'];
   /** An object relationship */
-  parent_categories: Parent_Categories;
-  parent_category_id: Scalars["Int"];
+  parentCategories: Parent_Categories;
+  parentCategoryId: Scalars['Int'];
   /** An object relationship */
-  sub_categories?: Maybe<Circles>;
+  subCategories?: Maybe<Circles>;
 };
+
 
 /** columns and relationships of "sub_categories" */
 export type Sub_CategoriesCirclesArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
 
+
 /** columns and relationships of "sub_categories" */
 export type Sub_CategoriesCircles_AggregateArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
 
 /** aggregated selection of "sub_categories" */
 export type Sub_Categories_Aggregate = {
-  __typename?: "sub_categories_aggregate";
+  __typename?: 'sub_categories_aggregate';
   aggregate?: Maybe<Sub_Categories_Aggregate_Fields>;
   nodes: Array<Sub_Categories>;
 };
 
 /** aggregate fields of "sub_categories" */
 export type Sub_Categories_Aggregate_Fields = {
-  __typename?: "sub_categories_aggregate_fields";
+  __typename?: 'sub_categories_aggregate_fields';
   avg?: Maybe<Sub_Categories_Avg_Fields>;
-  count?: Maybe<Scalars["Int"]>;
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Sub_Categories_Max_Fields>;
   min?: Maybe<Sub_Categories_Min_Fields>;
   stddev?: Maybe<Sub_Categories_Stddev_Fields>;
@@ -3049,10 +3162,11 @@ export type Sub_Categories_Aggregate_Fields = {
   variance?: Maybe<Sub_Categories_Variance_Fields>;
 };
 
+
 /** aggregate fields of "sub_categories" */
 export type Sub_Categories_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Sub_Categories_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "sub_categories" */
@@ -3078,15 +3192,15 @@ export type Sub_Categories_Arr_Rel_Insert_Input = {
 
 /** aggregate avg on columns */
 export type Sub_Categories_Avg_Fields = {
-  __typename?: "sub_categories_avg_fields";
-  id?: Maybe<Scalars["Float"]>;
-  parent_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'sub_categories_avg_fields';
+  id?: Maybe<Scalars['Float']>;
+  parentCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "sub_categories" */
 export type Sub_Categories_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "sub_categories". All fields are combined with a logical 'AND'. */
@@ -3097,68 +3211,68 @@ export type Sub_Categories_Bool_Exp = {
   circles?: Maybe<Circles_Bool_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   name?: Maybe<String_Comparison_Exp>;
-  parent_categories?: Maybe<Parent_Categories_Bool_Exp>;
-  parent_category_id?: Maybe<Int_Comparison_Exp>;
-  sub_categories?: Maybe<Circles_Bool_Exp>;
+  parentCategories?: Maybe<Parent_Categories_Bool_Exp>;
+  parentCategoryId?: Maybe<Int_Comparison_Exp>;
+  subCategories?: Maybe<Circles_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "sub_categories" */
 export enum Sub_Categories_Constraint {
   /** unique or primary key constraint */
-  SubCategoryPkey = "SubCategory_pkey",
+  SubCategoryPkey = 'SubCategory_pkey'
 }
 
 /** input type for incrementing integer column in table "sub_categories" */
 export type Sub_Categories_Inc_Input = {
-  id?: Maybe<Scalars["Int"]>;
-  parent_category_id?: Maybe<Scalars["Int"]>;
+  id?: Maybe<Scalars['Int']>;
+  parentCategoryId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "sub_categories" */
 export type Sub_Categories_Insert_Input = {
   circles?: Maybe<Circles_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
-  parent_categories?: Maybe<Parent_Categories_Obj_Rel_Insert_Input>;
-  parent_category_id?: Maybe<Scalars["Int"]>;
-  sub_categories?: Maybe<Circles_Obj_Rel_Insert_Input>;
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
+  parentCategories?: Maybe<Parent_Categories_Obj_Rel_Insert_Input>;
+  parentCategoryId?: Maybe<Scalars['Int']>;
+  subCategories?: Maybe<Circles_Obj_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
 export type Sub_Categories_Max_Fields = {
-  __typename?: "sub_categories_max_fields";
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
-  parent_category_id?: Maybe<Scalars["Int"]>;
+  __typename?: 'sub_categories_max_fields';
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
+  parentCategoryId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "sub_categories" */
 export type Sub_Categories_Max_Order_By = {
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Sub_Categories_Min_Fields = {
-  __typename?: "sub_categories_min_fields";
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
-  parent_category_id?: Maybe<Scalars["Int"]>;
+  __typename?: 'sub_categories_min_fields';
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
+  parentCategoryId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "sub_categories" */
 export type Sub_Categories_Min_Order_By = {
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "sub_categories" */
 export type Sub_Categories_Mutation_Response = {
-  __typename?: "sub_categories_mutation_response";
+  __typename?: 'sub_categories_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Sub_Categories>;
 };
@@ -3181,145 +3295,145 @@ export type Sub_Categories_Order_By = {
   circles_aggregate?: Maybe<Circles_Aggregate_Order_By>;
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  parent_categories?: Maybe<Parent_Categories_Order_By>;
-  parent_category_id?: Maybe<Order_By>;
-  sub_categories?: Maybe<Circles_Order_By>;
+  parentCategories?: Maybe<Parent_Categories_Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
+  subCategories?: Maybe<Circles_Order_By>;
 };
 
 /** primary key columns input for table: "sub_categories" */
 export type Sub_Categories_Pk_Columns_Input = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
 
 /** select columns of table "sub_categories" */
 export enum Sub_Categories_Select_Column {
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Name = "name",
+  Name = 'name',
   /** column name */
-  ParentCategoryId = "parent_category_id",
+  ParentCategoryId = 'parentCategoryId'
 }
 
 /** input type for updating data in table "sub_categories" */
 export type Sub_Categories_Set_Input = {
-  id?: Maybe<Scalars["Int"]>;
-  name?: Maybe<Scalars["String"]>;
-  parent_category_id?: Maybe<Scalars["Int"]>;
+  id?: Maybe<Scalars['Int']>;
+  name?: Maybe<Scalars['String']>;
+  parentCategoryId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type Sub_Categories_Stddev_Fields = {
-  __typename?: "sub_categories_stddev_fields";
-  id?: Maybe<Scalars["Float"]>;
-  parent_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'sub_categories_stddev_fields';
+  id?: Maybe<Scalars['Float']>;
+  parentCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "sub_categories" */
 export type Sub_Categories_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Sub_Categories_Stddev_Pop_Fields = {
-  __typename?: "sub_categories_stddev_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
-  parent_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'sub_categories_stddev_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+  parentCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "sub_categories" */
 export type Sub_Categories_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Sub_Categories_Stddev_Samp_Fields = {
-  __typename?: "sub_categories_stddev_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
-  parent_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'sub_categories_stddev_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+  parentCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "sub_categories" */
 export type Sub_Categories_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Sub_Categories_Sum_Fields = {
-  __typename?: "sub_categories_sum_fields";
-  id?: Maybe<Scalars["Int"]>;
-  parent_category_id?: Maybe<Scalars["Int"]>;
+  __typename?: 'sub_categories_sum_fields';
+  id?: Maybe<Scalars['Int']>;
+  parentCategoryId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "sub_categories" */
 export type Sub_Categories_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** update columns of table "sub_categories" */
 export enum Sub_Categories_Update_Column {
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Name = "name",
+  Name = 'name',
   /** column name */
-  ParentCategoryId = "parent_category_id",
+  ParentCategoryId = 'parentCategoryId'
 }
 
 /** aggregate var_pop on columns */
 export type Sub_Categories_Var_Pop_Fields = {
-  __typename?: "sub_categories_var_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
-  parent_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'sub_categories_var_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+  parentCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "sub_categories" */
 export type Sub_Categories_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Sub_Categories_Var_Samp_Fields = {
-  __typename?: "sub_categories_var_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
-  parent_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'sub_categories_var_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+  parentCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "sub_categories" */
 export type Sub_Categories_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Sub_Categories_Variance_Fields = {
-  __typename?: "sub_categories_variance_fields";
-  id?: Maybe<Scalars["Float"]>;
-  parent_category_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'sub_categories_variance_fields';
+  id?: Maybe<Scalars['Float']>;
+  parentCategoryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "sub_categories" */
 export type Sub_Categories_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  parent_category_id?: Maybe<Order_By>;
+  parentCategoryId?: Maybe<Order_By>;
 };
 
 /** subscription root */
 export type Subscription_Root = {
-  __typename?: "subscription_root";
+  __typename?: 'subscription_root';
   /** fetch data from the table: "circle_skills" */
-  circle_skills: Array<Circle_Skills>;
+  circleSkills: Array<Circle_Skills>;
+  /** fetch data from the table: "circle_users" */
+  circleUsers: Array<Circle_Users>;
   /** fetch aggregated fields from the table: "circle_skills" */
   circle_skills_aggregate: Circle_Skills_Aggregate;
   /** fetch data from the table: "circle_skills" using primary key columns */
   circle_skills_by_pk?: Maybe<Circle_Skills>;
-  /** fetch data from the table: "circle_users" */
-  circle_users: Array<Circle_Users>;
   /** fetch aggregated fields from the table: "circle_users" */
   circle_users_aggregate: Circle_Users_Aggregate;
   /** fetch data from the table: "circle_users" using primary key columns */
@@ -3343,7 +3457,7 @@ export type Subscription_Root = {
   /** fetch data from the table: "organizations" using primary key columns */
   organizations_by_pk?: Maybe<Organizations>;
   /** fetch data from the table: "parent_categories" */
-  parent_categories: Array<Parent_Categories>;
+  parentCategories: Array<Parent_Categories>;
   /** fetch aggregated fields from the table: "parent_categories" */
   parent_categories_aggregate: Parent_Categories_Aggregate;
   /** fetch data from the table: "parent_categories" using primary key columns */
@@ -3355,13 +3469,13 @@ export type Subscription_Root = {
   /** fetch data from the table: "skills" using primary key columns */
   skills_by_pk?: Maybe<Skills>;
   /** fetch data from the table: "sub_categories" */
-  sub_categories: Array<Sub_Categories>;
+  subCategories: Array<Sub_Categories>;
+  /** fetch data from the table: "sub_categories" using primary key columns */
+  subCategory?: Maybe<Sub_Categories>;
   /** fetch aggregated fields from the table: "sub_categories" */
   sub_categories_aggregate: Sub_Categories_Aggregate;
-  /** fetch data from the table: "sub_categories" using primary key columns */
-  sub_categories_by_pk?: Maybe<Sub_Categories>;
   /** fetch data from the table: "user_skills" */
-  user_skills: Array<User_Skills>;
+  userSkills: Array<User_Skills>;
   /** fetch aggregated fields from the table: "user_skills" */
   user_skills_aggregate: User_Skills_Aggregate;
   /** fetch data from the table: "user_skills" using primary key columns */
@@ -3374,274 +3488,305 @@ export type Subscription_Root = {
   users_by_pk?: Maybe<Users>;
 };
 
+
 /** subscription root */
-export type Subscription_RootCircle_SkillsArgs = {
+export type Subscription_RootCircleSkillsArgs = {
   distinct_on?: Maybe<Array<Circle_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Skills_Order_By>>;
   where?: Maybe<Circle_Skills_Bool_Exp>;
 };
+
+
+/** subscription root */
+export type Subscription_RootCircleUsersArgs = {
+  distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Circle_Users_Order_By>>;
+  where?: Maybe<Circle_Users_Bool_Exp>;
+};
+
 
 /** subscription root */
 export type Subscription_RootCircle_Skills_AggregateArgs = {
   distinct_on?: Maybe<Array<Circle_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Skills_Order_By>>;
   where?: Maybe<Circle_Skills_Bool_Exp>;
 };
 
-/** subscription root */
-export type Subscription_RootCircle_Skills_By_PkArgs = {
-  id: Scalars["Int"];
-};
 
 /** subscription root */
-export type Subscription_RootCircle_UsersArgs = {
-  distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
-  order_by?: Maybe<Array<Circle_Users_Order_By>>;
-  where?: Maybe<Circle_Users_Bool_Exp>;
+export type Subscription_RootCircle_Skills_By_PkArgs = {
+  id: Scalars['Int'];
 };
+
 
 /** subscription root */
 export type Subscription_RootCircle_Users_AggregateArgs = {
   distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Users_Order_By>>;
   where?: Maybe<Circle_Users_Bool_Exp>;
 };
 
+
 /** subscription root */
 export type Subscription_RootCircle_Users_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** subscription root */
 export type Subscription_RootCirclesArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
+
 
 /** subscription root */
 export type Subscription_RootCircles_AggregateArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
 
+
 /** subscription root */
 export type Subscription_RootCircles_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** subscription root */
 export type Subscription_RootMessagesArgs = {
   distinct_on?: Maybe<Array<Messages_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Messages_Order_By>>;
   where?: Maybe<Messages_Bool_Exp>;
 };
+
 
 /** subscription root */
 export type Subscription_RootMessages_AggregateArgs = {
   distinct_on?: Maybe<Array<Messages_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Messages_Order_By>>;
   where?: Maybe<Messages_Bool_Exp>;
 };
 
+
 /** subscription root */
 export type Subscription_RootMessages_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** subscription root */
 export type Subscription_RootOrganizationsArgs = {
   distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Organizations_Order_By>>;
   where?: Maybe<Organizations_Bool_Exp>;
 };
+
 
 /** subscription root */
 export type Subscription_RootOrganizations_AggregateArgs = {
   distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Organizations_Order_By>>;
   where?: Maybe<Organizations_Bool_Exp>;
 };
 
-/** subscription root */
-export type Subscription_RootOrganizations_By_PkArgs = {
-  id: Scalars["String"];
-};
 
 /** subscription root */
-export type Subscription_RootParent_CategoriesArgs = {
+export type Subscription_RootOrganizations_By_PkArgs = {
+  id: Scalars['String'];
+};
+
+
+/** subscription root */
+export type Subscription_RootParentCategoriesArgs = {
   distinct_on?: Maybe<Array<Parent_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Parent_Categories_Order_By>>;
   where?: Maybe<Parent_Categories_Bool_Exp>;
 };
+
 
 /** subscription root */
 export type Subscription_RootParent_Categories_AggregateArgs = {
   distinct_on?: Maybe<Array<Parent_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Parent_Categories_Order_By>>;
   where?: Maybe<Parent_Categories_Bool_Exp>;
 };
 
+
 /** subscription root */
 export type Subscription_RootParent_Categories_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** subscription root */
 export type Subscription_RootSkillsArgs = {
   distinct_on?: Maybe<Array<Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Skills_Order_By>>;
   where?: Maybe<Skills_Bool_Exp>;
 };
+
 
 /** subscription root */
 export type Subscription_RootSkills_AggregateArgs = {
   distinct_on?: Maybe<Array<Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Skills_Order_By>>;
   where?: Maybe<Skills_Bool_Exp>;
 };
 
-/** subscription root */
-export type Subscription_RootSkills_By_PkArgs = {
-  id: Scalars["Int"];
-};
 
 /** subscription root */
-export type Subscription_RootSub_CategoriesArgs = {
+export type Subscription_RootSkills_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type Subscription_RootSubCategoriesArgs = {
   distinct_on?: Maybe<Array<Sub_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Sub_Categories_Order_By>>;
   where?: Maybe<Sub_Categories_Bool_Exp>;
 };
+
+
+/** subscription root */
+export type Subscription_RootSubCategoryArgs = {
+  id: Scalars['Int'];
+};
+
 
 /** subscription root */
 export type Subscription_RootSub_Categories_AggregateArgs = {
   distinct_on?: Maybe<Array<Sub_Categories_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Sub_Categories_Order_By>>;
   where?: Maybe<Sub_Categories_Bool_Exp>;
 };
 
-/** subscription root */
-export type Subscription_RootSub_Categories_By_PkArgs = {
-  id: Scalars["Int"];
-};
 
 /** subscription root */
-export type Subscription_RootUser_SkillsArgs = {
+export type Subscription_RootUserSkillsArgs = {
   distinct_on?: Maybe<Array<User_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<User_Skills_Order_By>>;
   where?: Maybe<User_Skills_Bool_Exp>;
 };
+
 
 /** subscription root */
 export type Subscription_RootUser_Skills_AggregateArgs = {
   distinct_on?: Maybe<Array<User_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<User_Skills_Order_By>>;
   where?: Maybe<User_Skills_Bool_Exp>;
 };
 
+
 /** subscription root */
 export type Subscription_RootUser_Skills_By_PkArgs = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
+
 
 /** subscription root */
 export type Subscription_RootUsersArgs = {
   distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Users_Order_By>>;
   where?: Maybe<Users_Bool_Exp>;
 };
+
 
 /** subscription root */
 export type Subscription_RootUsers_AggregateArgs = {
   distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Users_Order_By>>;
   where?: Maybe<Users_Bool_Exp>;
 };
 
+
 /** subscription root */
 export type Subscription_RootUsers_By_PkArgs = {
-  id: Scalars["String"];
+  id: Scalars['String'];
 };
+
 
 /** expression to compare columns of type timestamptz. All fields are combined with logical 'AND'. */
 export type Timestamptz_Comparison_Exp = {
-  _eq?: Maybe<Scalars["timestamptz"]>;
-  _gt?: Maybe<Scalars["timestamptz"]>;
-  _gte?: Maybe<Scalars["timestamptz"]>;
-  _in?: Maybe<Array<Scalars["timestamptz"]>>;
-  _is_null?: Maybe<Scalars["Boolean"]>;
-  _lt?: Maybe<Scalars["timestamptz"]>;
-  _lte?: Maybe<Scalars["timestamptz"]>;
-  _neq?: Maybe<Scalars["timestamptz"]>;
-  _nin?: Maybe<Array<Scalars["timestamptz"]>>;
+  _eq?: Maybe<Scalars['timestamptz']>;
+  _gt?: Maybe<Scalars['timestamptz']>;
+  _gte?: Maybe<Scalars['timestamptz']>;
+  _in?: Maybe<Array<Scalars['timestamptz']>>;
+  _is_null?: Maybe<Scalars['Boolean']>;
+  _lt?: Maybe<Scalars['timestamptz']>;
+  _lte?: Maybe<Scalars['timestamptz']>;
+  _neq?: Maybe<Scalars['timestamptz']>;
+  _nin?: Maybe<Array<Scalars['timestamptz']>>;
 };
 
 /** columns and relationships of "user_skills" */
 export type User_Skills = {
-  __typename?: "user_skills";
-  id: Scalars["Int"];
-  level: Scalars["Int"];
-  skill_id: Scalars["Int"];
+  __typename?: 'user_skills';
+  id: Scalars['Int'];
+  level: Scalars['Int'];
   /** An object relationship */
-  skills: Skills;
-  user_id: Scalars["String"];
+  skill: Skills;
+  skillId: Scalars['Int'];
   /** An object relationship */
-  users: Users;
+  user: Users;
+  userId: Scalars['String'];
 };
 
 /** aggregated selection of "user_skills" */
 export type User_Skills_Aggregate = {
-  __typename?: "user_skills_aggregate";
+  __typename?: 'user_skills_aggregate';
   aggregate?: Maybe<User_Skills_Aggregate_Fields>;
   nodes: Array<User_Skills>;
 };
 
 /** aggregate fields of "user_skills" */
 export type User_Skills_Aggregate_Fields = {
-  __typename?: "user_skills_aggregate_fields";
+  __typename?: 'user_skills_aggregate_fields';
   avg?: Maybe<User_Skills_Avg_Fields>;
-  count?: Maybe<Scalars["Int"]>;
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<User_Skills_Max_Fields>;
   min?: Maybe<User_Skills_Min_Fields>;
   stddev?: Maybe<User_Skills_Stddev_Fields>;
@@ -3653,10 +3798,11 @@ export type User_Skills_Aggregate_Fields = {
   variance?: Maybe<User_Skills_Variance_Fields>;
 };
 
+
 /** aggregate fields of "user_skills" */
 export type User_Skills_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<User_Skills_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "user_skills" */
@@ -3682,17 +3828,17 @@ export type User_Skills_Arr_Rel_Insert_Input = {
 
 /** aggregate avg on columns */
 export type User_Skills_Avg_Fields = {
-  __typename?: "user_skills_avg_fields";
-  id?: Maybe<Scalars["Float"]>;
-  level?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'user_skills_avg_fields';
+  id?: Maybe<Scalars['Float']>;
+  level?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "user_skills" */
 export type User_Skills_Avg_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "user_skills". All fields are combined with a logical 'AND'. */
@@ -3702,74 +3848,74 @@ export type User_Skills_Bool_Exp = {
   _or?: Maybe<Array<Maybe<User_Skills_Bool_Exp>>>;
   id?: Maybe<Int_Comparison_Exp>;
   level?: Maybe<Int_Comparison_Exp>;
-  skill_id?: Maybe<Int_Comparison_Exp>;
-  skills?: Maybe<Skills_Bool_Exp>;
-  user_id?: Maybe<String_Comparison_Exp>;
-  users?: Maybe<Users_Bool_Exp>;
+  skill?: Maybe<Skills_Bool_Exp>;
+  skillId?: Maybe<Int_Comparison_Exp>;
+  user?: Maybe<Users_Bool_Exp>;
+  userId?: Maybe<String_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "user_skills" */
 export enum User_Skills_Constraint {
   /** unique or primary key constraint */
-  UserSkillPkey = "UserSkill_pkey",
+  UserSkillPkey = 'UserSkill_pkey'
 }
 
 /** input type for incrementing integer column in table "user_skills" */
 export type User_Skills_Inc_Input = {
-  id?: Maybe<Scalars["Int"]>;
-  level?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
+  id?: Maybe<Scalars['Int']>;
+  level?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "user_skills" */
 export type User_Skills_Insert_Input = {
-  id?: Maybe<Scalars["Int"]>;
-  level?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
-  skills?: Maybe<Skills_Obj_Rel_Insert_Input>;
-  user_id?: Maybe<Scalars["String"]>;
-  users?: Maybe<Users_Obj_Rel_Insert_Input>;
+  id?: Maybe<Scalars['Int']>;
+  level?: Maybe<Scalars['Int']>;
+  skill?: Maybe<Skills_Obj_Rel_Insert_Input>;
+  skillId?: Maybe<Scalars['Int']>;
+  user?: Maybe<Users_Obj_Rel_Insert_Input>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** aggregate max on columns */
 export type User_Skills_Max_Fields = {
-  __typename?: "user_skills_max_fields";
-  id?: Maybe<Scalars["Int"]>;
-  level?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  __typename?: 'user_skills_max_fields';
+  id?: Maybe<Scalars['Int']>;
+  level?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "user_skills" */
 export type User_Skills_Max_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type User_Skills_Min_Fields = {
-  __typename?: "user_skills_min_fields";
-  id?: Maybe<Scalars["Int"]>;
-  level?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  __typename?: 'user_skills_min_fields';
+  id?: Maybe<Scalars['Int']>;
+  level?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "user_skills" */
 export type User_Skills_Min_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "user_skills" */
 export type User_Skills_Mutation_Response = {
-  __typename?: "user_skills_mutation_response";
+  __typename?: 'user_skills_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<User_Skills>;
 };
@@ -3791,279 +3937,288 @@ export type User_Skills_On_Conflict = {
 export type User_Skills_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
-  skills?: Maybe<Skills_Order_By>;
-  user_id?: Maybe<Order_By>;
-  users?: Maybe<Users_Order_By>;
+  skill?: Maybe<Skills_Order_By>;
+  skillId?: Maybe<Order_By>;
+  user?: Maybe<Users_Order_By>;
+  userId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "user_skills" */
 export type User_Skills_Pk_Columns_Input = {
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 };
 
 /** select columns of table "user_skills" */
 export enum User_Skills_Select_Column {
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Level = "level",
+  Level = 'level',
   /** column name */
-  SkillId = "skill_id",
+  SkillId = 'skillId',
   /** column name */
-  UserId = "user_id",
+  UserId = 'userId'
 }
 
 /** input type for updating data in table "user_skills" */
 export type User_Skills_Set_Input = {
-  id?: Maybe<Scalars["Int"]>;
-  level?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
-  user_id?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars['Int']>;
+  level?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
+  userId?: Maybe<Scalars['String']>;
 };
 
 /** aggregate stddev on columns */
 export type User_Skills_Stddev_Fields = {
-  __typename?: "user_skills_stddev_fields";
-  id?: Maybe<Scalars["Float"]>;
-  level?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'user_skills_stddev_fields';
+  id?: Maybe<Scalars['Float']>;
+  level?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "user_skills" */
 export type User_Skills_Stddev_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type User_Skills_Stddev_Pop_Fields = {
-  __typename?: "user_skills_stddev_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
-  level?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'user_skills_stddev_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+  level?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "user_skills" */
 export type User_Skills_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type User_Skills_Stddev_Samp_Fields = {
-  __typename?: "user_skills_stddev_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
-  level?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'user_skills_stddev_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+  level?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "user_skills" */
 export type User_Skills_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type User_Skills_Sum_Fields = {
-  __typename?: "user_skills_sum_fields";
-  id?: Maybe<Scalars["Int"]>;
-  level?: Maybe<Scalars["Int"]>;
-  skill_id?: Maybe<Scalars["Int"]>;
+  __typename?: 'user_skills_sum_fields';
+  id?: Maybe<Scalars['Int']>;
+  level?: Maybe<Scalars['Int']>;
+  skillId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "user_skills" */
 export type User_Skills_Sum_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** update columns of table "user_skills" */
 export enum User_Skills_Update_Column {
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  Level = "level",
+  Level = 'level',
   /** column name */
-  SkillId = "skill_id",
+  SkillId = 'skillId',
   /** column name */
-  UserId = "user_id",
+  UserId = 'userId'
 }
 
 /** aggregate var_pop on columns */
 export type User_Skills_Var_Pop_Fields = {
-  __typename?: "user_skills_var_pop_fields";
-  id?: Maybe<Scalars["Float"]>;
-  level?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'user_skills_var_pop_fields';
+  id?: Maybe<Scalars['Float']>;
+  level?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "user_skills" */
 export type User_Skills_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type User_Skills_Var_Samp_Fields = {
-  __typename?: "user_skills_var_samp_fields";
-  id?: Maybe<Scalars["Float"]>;
-  level?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'user_skills_var_samp_fields';
+  id?: Maybe<Scalars['Float']>;
+  level?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "user_skills" */
 export type User_Skills_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type User_Skills_Variance_Fields = {
-  __typename?: "user_skills_variance_fields";
-  id?: Maybe<Scalars["Float"]>;
-  level?: Maybe<Scalars["Float"]>;
-  skill_id?: Maybe<Scalars["Float"]>;
+  __typename?: 'user_skills_variance_fields';
+  id?: Maybe<Scalars['Float']>;
+  level?: Maybe<Scalars['Float']>;
+  skillId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "user_skills" */
 export type User_Skills_Variance_Order_By = {
   id?: Maybe<Order_By>;
   level?: Maybe<Order_By>;
-  skill_id?: Maybe<Order_By>;
+  skillId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "users" */
 export type Users = {
-  __typename?: "users";
-  avatar?: Maybe<Scalars["String"]>;
+  __typename?: 'users';
+  avatar?: Maybe<Scalars['String']>;
   /** An array relationship */
-  circle_users: Array<Circle_Users>;
+  circleUsers: Array<Circle_Users>;
   /** An aggregated array relationship */
-  circle_users_aggregate: Circle_Users_Aggregate;
+  circleUsers_aggregate: Circle_Users_Aggregate;
   /** An array relationship */
   circles: Array<Circles>;
   /** An aggregated array relationship */
   circles_aggregate: Circles_Aggregate;
-  created_at?: Maybe<Scalars["timestamptz"]>;
-  email?: Maybe<Scalars["String"]>;
-  id: Scalars["String"];
-  interested_in?: Maybe<Scalars["String"]>;
-  introduction?: Maybe<Scalars["String"]>;
-  last_seen?: Maybe<Scalars["timestamptz"]>;
+  createdAt?: Maybe<Scalars['timestamptz']>;
+  email?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  interestedIn?: Maybe<Scalars['String']>;
+  introduction?: Maybe<Scalars['String']>;
+  lastSeen?: Maybe<Scalars['timestamptz']>;
   /** An array relationship */
   messages: Array<Messages>;
   /** An aggregated array relationship */
   messages_aggregate: Messages_Aggregate;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
   /** An object relationship */
   organizations?: Maybe<Organizations>;
   /** An array relationship */
-  user_skills: Array<User_Skills>;
+  userSkills: Array<User_Skills>;
   /** An aggregated array relationship */
-  user_skills_aggregate: User_Skills_Aggregate;
+  userSkills_aggregate: User_Skills_Aggregate;
   /** An object relationship */
   users?: Maybe<Circles>;
 };
 
+
 /** columns and relationships of "users" */
-export type UsersCircle_UsersArgs = {
+export type UsersCircleUsersArgs = {
   distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Users_Order_By>>;
   where?: Maybe<Circle_Users_Bool_Exp>;
 };
 
+
 /** columns and relationships of "users" */
-export type UsersCircle_Users_AggregateArgs = {
+export type UsersCircleUsers_AggregateArgs = {
   distinct_on?: Maybe<Array<Circle_Users_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circle_Users_Order_By>>;
   where?: Maybe<Circle_Users_Bool_Exp>;
 };
+
 
 /** columns and relationships of "users" */
 export type UsersCirclesArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
+
 
 /** columns and relationships of "users" */
 export type UsersCircles_AggregateArgs = {
   distinct_on?: Maybe<Array<Circles_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Circles_Order_By>>;
   where?: Maybe<Circles_Bool_Exp>;
 };
 
+
 /** columns and relationships of "users" */
 export type UsersMessagesArgs = {
   distinct_on?: Maybe<Array<Messages_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Messages_Order_By>>;
   where?: Maybe<Messages_Bool_Exp>;
 };
+
 
 /** columns and relationships of "users" */
 export type UsersMessages_AggregateArgs = {
   distinct_on?: Maybe<Array<Messages_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Messages_Order_By>>;
   where?: Maybe<Messages_Bool_Exp>;
 };
 
+
 /** columns and relationships of "users" */
-export type UsersUser_SkillsArgs = {
+export type UsersUserSkillsArgs = {
   distinct_on?: Maybe<Array<User_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<User_Skills_Order_By>>;
   where?: Maybe<User_Skills_Bool_Exp>;
 };
 
+
 /** columns and relationships of "users" */
-export type UsersUser_Skills_AggregateArgs = {
+export type UsersUserSkills_AggregateArgs = {
   distinct_on?: Maybe<Array<User_Skills_Select_Column>>;
-  limit?: Maybe<Scalars["Int"]>;
-  offset?: Maybe<Scalars["Int"]>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<User_Skills_Order_By>>;
   where?: Maybe<User_Skills_Bool_Exp>;
 };
 
 /** aggregated selection of "users" */
 export type Users_Aggregate = {
-  __typename?: "users_aggregate";
+  __typename?: 'users_aggregate';
   aggregate?: Maybe<Users_Aggregate_Fields>;
   nodes: Array<Users>;
 };
 
 /** aggregate fields of "users" */
 export type Users_Aggregate_Fields = {
-  __typename?: "users_aggregate_fields";
-  count?: Maybe<Scalars["Int"]>;
+  __typename?: 'users_aggregate_fields';
+  count?: Maybe<Scalars['Int']>;
   max?: Maybe<Users_Max_Fields>;
   min?: Maybe<Users_Min_Fields>;
 };
 
+
 /** aggregate fields of "users" */
 export type Users_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Users_Select_Column>>;
-  distinct?: Maybe<Scalars["Boolean"]>;
+  distinct?: Maybe<Scalars['Boolean']>;
 };
 
 /** order by aggregate values of table "users" */
@@ -4085,106 +4240,106 @@ export type Users_Bool_Exp = {
   _not?: Maybe<Users_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Users_Bool_Exp>>>;
   avatar?: Maybe<String_Comparison_Exp>;
-  circle_users?: Maybe<Circle_Users_Bool_Exp>;
+  circleUsers?: Maybe<Circle_Users_Bool_Exp>;
   circles?: Maybe<Circles_Bool_Exp>;
-  created_at?: Maybe<Timestamptz_Comparison_Exp>;
+  createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   email?: Maybe<String_Comparison_Exp>;
   id?: Maybe<String_Comparison_Exp>;
-  interested_in?: Maybe<String_Comparison_Exp>;
+  interestedIn?: Maybe<String_Comparison_Exp>;
   introduction?: Maybe<String_Comparison_Exp>;
-  last_seen?: Maybe<Timestamptz_Comparison_Exp>;
+  lastSeen?: Maybe<Timestamptz_Comparison_Exp>;
   messages?: Maybe<Messages_Bool_Exp>;
   name?: Maybe<String_Comparison_Exp>;
-  organization_id?: Maybe<String_Comparison_Exp>;
+  organizationId?: Maybe<String_Comparison_Exp>;
   organizations?: Maybe<Organizations_Bool_Exp>;
-  user_skills?: Maybe<User_Skills_Bool_Exp>;
+  userSkills?: Maybe<User_Skills_Bool_Exp>;
   users?: Maybe<Circles_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "users" */
 export enum Users_Constraint {
   /** unique or primary key constraint */
-  UserPkey = "user_pkey",
+  UserPkey = 'user_pkey'
 }
 
 /** input type for inserting data into table "users" */
 export type Users_Insert_Input = {
-  avatar?: Maybe<Scalars["String"]>;
-  circle_users?: Maybe<Circle_Users_Arr_Rel_Insert_Input>;
+  avatar?: Maybe<Scalars['String']>;
+  circleUsers?: Maybe<Circle_Users_Arr_Rel_Insert_Input>;
   circles?: Maybe<Circles_Arr_Rel_Insert_Input>;
-  created_at?: Maybe<Scalars["timestamptz"]>;
-  email?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["String"]>;
-  interested_in?: Maybe<Scalars["String"]>;
-  introduction?: Maybe<Scalars["String"]>;
-  last_seen?: Maybe<Scalars["timestamptz"]>;
+  createdAt?: Maybe<Scalars['timestamptz']>;
+  email?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['String']>;
+  interestedIn?: Maybe<Scalars['String']>;
+  introduction?: Maybe<Scalars['String']>;
+  lastSeen?: Maybe<Scalars['timestamptz']>;
   messages?: Maybe<Messages_Arr_Rel_Insert_Input>;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
   organizations?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  user_skills?: Maybe<User_Skills_Arr_Rel_Insert_Input>;
+  userSkills?: Maybe<User_Skills_Arr_Rel_Insert_Input>;
   users?: Maybe<Circles_Obj_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
 export type Users_Max_Fields = {
-  __typename?: "users_max_fields";
-  avatar?: Maybe<Scalars["String"]>;
-  created_at?: Maybe<Scalars["timestamptz"]>;
-  email?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["String"]>;
-  interested_in?: Maybe<Scalars["String"]>;
-  introduction?: Maybe<Scalars["String"]>;
-  last_seen?: Maybe<Scalars["timestamptz"]>;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
+  __typename?: 'users_max_fields';
+  avatar?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['timestamptz']>;
+  email?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['String']>;
+  interestedIn?: Maybe<Scalars['String']>;
+  introduction?: Maybe<Scalars['String']>;
+  lastSeen?: Maybe<Scalars['timestamptz']>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "users" */
 export type Users_Max_Order_By = {
   avatar?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
+  createdAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  interested_in?: Maybe<Order_By>;
+  interestedIn?: Maybe<Order_By>;
   introduction?: Maybe<Order_By>;
-  last_seen?: Maybe<Order_By>;
+  lastSeen?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
+  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Users_Min_Fields = {
-  __typename?: "users_min_fields";
-  avatar?: Maybe<Scalars["String"]>;
-  created_at?: Maybe<Scalars["timestamptz"]>;
-  email?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["String"]>;
-  interested_in?: Maybe<Scalars["String"]>;
-  introduction?: Maybe<Scalars["String"]>;
-  last_seen?: Maybe<Scalars["timestamptz"]>;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
+  __typename?: 'users_min_fields';
+  avatar?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['timestamptz']>;
+  email?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['String']>;
+  interestedIn?: Maybe<Scalars['String']>;
+  introduction?: Maybe<Scalars['String']>;
+  lastSeen?: Maybe<Scalars['timestamptz']>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "users" */
 export type Users_Min_Order_By = {
   avatar?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
+  createdAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  interested_in?: Maybe<Order_By>;
+  interestedIn?: Maybe<Order_By>;
   introduction?: Maybe<Order_By>;
-  last_seen?: Maybe<Order_By>;
+  lastSeen?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
+  organizationId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "users" */
 export type Users_Mutation_Response = {
-  __typename?: "users_mutation_response";
+  __typename?: 'users_mutation_response';
   /** number of affected rows by the mutation */
-  affected_rows: Scalars["Int"];
+  affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Users>;
 };
@@ -4205,317 +4360,292 @@ export type Users_On_Conflict = {
 /** ordering options when selecting data from "users" */
 export type Users_Order_By = {
   avatar?: Maybe<Order_By>;
-  circle_users_aggregate?: Maybe<Circle_Users_Aggregate_Order_By>;
+  circleUsers_aggregate?: Maybe<Circle_Users_Aggregate_Order_By>;
   circles_aggregate?: Maybe<Circles_Aggregate_Order_By>;
-  created_at?: Maybe<Order_By>;
+  createdAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  interested_in?: Maybe<Order_By>;
+  interestedIn?: Maybe<Order_By>;
   introduction?: Maybe<Order_By>;
-  last_seen?: Maybe<Order_By>;
+  lastSeen?: Maybe<Order_By>;
   messages_aggregate?: Maybe<Messages_Aggregate_Order_By>;
   name?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
+  organizationId?: Maybe<Order_By>;
   organizations?: Maybe<Organizations_Order_By>;
-  user_skills_aggregate?: Maybe<User_Skills_Aggregate_Order_By>;
+  userSkills_aggregate?: Maybe<User_Skills_Aggregate_Order_By>;
   users?: Maybe<Circles_Order_By>;
 };
 
 /** primary key columns input for table: "users" */
 export type Users_Pk_Columns_Input = {
-  id: Scalars["String"];
+  id: Scalars['String'];
 };
 
 /** select columns of table "users" */
 export enum Users_Select_Column {
   /** column name */
-  Avatar = "avatar",
+  Avatar = 'avatar',
   /** column name */
-  CreatedAt = "created_at",
+  CreatedAt = 'createdAt',
   /** column name */
-  Email = "email",
+  Email = 'email',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  InterestedIn = "interested_in",
+  InterestedIn = 'interestedIn',
   /** column name */
-  Introduction = "introduction",
+  Introduction = 'introduction',
   /** column name */
-  LastSeen = "last_seen",
+  LastSeen = 'lastSeen',
   /** column name */
-  Name = "name",
+  Name = 'name',
   /** column name */
-  OrganizationId = "organization_id",
+  OrganizationId = 'organizationId'
 }
 
 /** input type for updating data in table "users" */
 export type Users_Set_Input = {
-  avatar?: Maybe<Scalars["String"]>;
-  created_at?: Maybe<Scalars["timestamptz"]>;
-  email?: Maybe<Scalars["String"]>;
-  id?: Maybe<Scalars["String"]>;
-  interested_in?: Maybe<Scalars["String"]>;
-  introduction?: Maybe<Scalars["String"]>;
-  last_seen?: Maybe<Scalars["timestamptz"]>;
-  name?: Maybe<Scalars["String"]>;
-  organization_id?: Maybe<Scalars["String"]>;
+  avatar?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['timestamptz']>;
+  email?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['String']>;
+  interestedIn?: Maybe<Scalars['String']>;
+  introduction?: Maybe<Scalars['String']>;
+  lastSeen?: Maybe<Scalars['timestamptz']>;
+  name?: Maybe<Scalars['String']>;
+  organizationId?: Maybe<Scalars['String']>;
 };
 
 /** update columns of table "users" */
 export enum Users_Update_Column {
   /** column name */
-  Avatar = "avatar",
+  Avatar = 'avatar',
   /** column name */
-  CreatedAt = "created_at",
+  CreatedAt = 'createdAt',
   /** column name */
-  Email = "email",
+  Email = 'email',
   /** column name */
-  Id = "id",
+  Id = 'id',
   /** column name */
-  InterestedIn = "interested_in",
+  InterestedIn = 'interestedIn',
   /** column name */
-  Introduction = "introduction",
+  Introduction = 'introduction',
   /** column name */
-  LastSeen = "last_seen",
+  LastSeen = 'lastSeen',
   /** column name */
-  Name = "name",
+  Name = 'name',
   /** column name */
-  OrganizationId = "organization_id",
+  OrganizationId = 'organizationId'
 }
 
 export type DeleteCircleSkillMutationVariables = Exact<{
-  circleId: Scalars["Int"];
-  skillId: Scalars["Int"];
+  circleId: Scalars['Int'];
+  skillId: Scalars['Int'];
 }>;
 
-export type DeleteCircleSkillMutation = { __typename?: "mutation_root" } & {
-  delete_circle_skills?: Maybe<
-    { __typename?: "circle_skills_mutation_response" } & Pick<
-      Circle_Skills_Mutation_Response,
-      "affected_rows"
-    >
-  >;
-};
+
+export type DeleteCircleSkillMutation = (
+  { __typename?: 'mutation_root' }
+  & { delete_circle_skills?: Maybe<(
+    { __typename?: 'circle_skills_mutation_response' }
+    & Pick<Circle_Skills_Mutation_Response, 'affected_rows'>
+  )> }
+);
 
 export type DeleteUserSkillMutationVariables = Exact<{
-  userId: Scalars["String"];
-  skillId: Scalars["Int"];
+  userId: Scalars['String'];
+  skillId: Scalars['Int'];
 }>;
 
-export type DeleteUserSkillMutation = { __typename?: "mutation_root" } & {
-  delete_user_skills?: Maybe<
-    { __typename?: "user_skills_mutation_response" } & Pick<
-      User_Skills_Mutation_Response,
-      "affected_rows"
-    >
-  >;
-};
+
+export type DeleteUserSkillMutation = (
+  { __typename?: 'mutation_root' }
+  & { delete_user_skills?: Maybe<(
+    { __typename?: 'user_skills_mutation_response' }
+    & Pick<User_Skills_Mutation_Response, 'affected_rows'>
+  )> }
+);
 
 export type InsertCircleMutationVariables = Exact<{
   objects: Array<Circles_Insert_Input>;
 }>;
 
-export type InsertCircleMutation = { __typename?: "mutation_root" } & {
-  insert_circles?: Maybe<
-    { __typename?: "circles_mutation_response" } & Pick<
-      Circles_Mutation_Response,
-      "affected_rows"
-    >
-  >;
-};
+
+export type InsertCircleMutation = (
+  { __typename?: 'mutation_root' }
+  & { insert_circles?: Maybe<(
+    { __typename?: 'circles_mutation_response' }
+    & Pick<Circles_Mutation_Response, 'affected_rows'>
+  )> }
+);
 
 export type InsertCircleSkillMutationVariables = Exact<{
-  circleId: Scalars["Int"];
-  skillId: Scalars["Int"];
+  circleId: Scalars['Int'];
+  skillId: Scalars['Int'];
 }>;
 
-export type InsertCircleSkillMutation = { __typename?: "mutation_root" } & {
-  insert_circle_skills?: Maybe<
-    { __typename?: "circle_skills_mutation_response" } & Pick<
-      Circle_Skills_Mutation_Response,
-      "affected_rows"
-    >
-  >;
-};
+
+export type InsertCircleSkillMutation = (
+  { __typename?: 'mutation_root' }
+  & { insert_circle_skills?: Maybe<(
+    { __typename?: 'circle_skills_mutation_response' }
+    & Pick<Circle_Skills_Mutation_Response, 'affected_rows'>
+  )> }
+);
 
 export type InsertUserSkillMutationVariables = Exact<{
-  userId: Scalars["String"];
-  skillId: Scalars["Int"];
+  userId: Scalars['String'];
+  skillId: Scalars['Int'];
 }>;
 
-export type InsertUserSkillMutation = { __typename?: "mutation_root" } & {
-  insert_user_skills?: Maybe<
-    { __typename?: "user_skills_mutation_response" } & Pick<
-      User_Skills_Mutation_Response,
-      "affected_rows"
-    >
-  >;
-};
+
+export type InsertUserSkillMutation = (
+  { __typename?: 'mutation_root' }
+  & { insert_user_skills?: Maybe<(
+    { __typename?: 'user_skills_mutation_response' }
+    & Pick<User_Skills_Mutation_Response, 'affected_rows'>
+  )> }
+);
 
 export type UpdateCirlceMutationVariables = Exact<{
-  id: Scalars["Int"];
+  id: Scalars['Int'];
   inputs?: Maybe<Circles_Set_Input>;
 }>;
 
-export type UpdateCirlceMutation = { __typename?: "mutation_root" } & {
-  update_circles?: Maybe<
-    { __typename?: "circles_mutation_response" } & Pick<
-      Circles_Mutation_Response,
-      "affected_rows"
-    >
-  >;
-};
+
+export type UpdateCirlceMutation = (
+  { __typename?: 'mutation_root' }
+  & { update_circles?: Maybe<(
+    { __typename?: 'circles_mutation_response' }
+    & Pick<Circles_Mutation_Response, 'affected_rows'>
+  )> }
+);
 
 export type UpdateUserMutationVariables = Exact<{
   _set?: Maybe<Users_Set_Input>;
   where: Users_Bool_Exp;
 }>;
 
-export type UpdateUserMutation = { __typename?: "mutation_root" } & {
-  update_users?: Maybe<
-    { __typename?: "users_mutation_response" } & Pick<
-      Users_Mutation_Response,
-      "affected_rows"
-    >
-  >;
-};
 
-export type CategoriesQueryVariables = Exact<{ [key: string]: never }>;
+export type UpdateUserMutation = (
+  { __typename?: 'mutation_root' }
+  & { update_users?: Maybe<(
+    { __typename?: 'users_mutation_response' }
+    & Pick<Users_Mutation_Response, 'affected_rows'>
+  )> }
+);
 
-export type CategoriesQuery = { __typename?: "query_root" } & {
-  parent_categories: Array<
-    { __typename?: "parent_categories" } & Pick<
-      Parent_Categories,
-      "id" | "name"
-    > & {
-        sub_categories: Array<
-          { __typename?: "sub_categories" } & Pick<
-            Sub_Categories,
-            "id" | "name"
-          >
-        >;
-      }
-  >;
-};
+export type CategoriesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CategoriesQuery = (
+  { __typename?: 'query_root' }
+  & { parentCategories: Array<(
+    { __typename?: 'parent_categories' }
+    & Pick<Parent_Categories, 'id' | 'name'>
+    & { subCategories: Array<(
+      { __typename?: 'sub_categories' }
+      & Pick<Sub_Categories, 'id' | 'name'>
+    )> }
+  )> }
+);
 
 export type CircleQueryVariables = Exact<{
-  id: Scalars["Int"];
+  id: Scalars['Int'];
 }>;
 
-export type CircleQuery = { __typename?: "query_root" } & {
-  circle?: Maybe<
-    { __typename?: "circles" } & Pick<
-      Circles,
-      | "id"
-      | "avatar"
-      | "name"
-      | "main_role"
-      | "what_we_will_do"
-      | "recruit_title"
-    > & {
-        owner?: Maybe<
-          { __typename?: "users" } & Pick<Users, "id" | "name" | "avatar">
-        >;
-        sub_categories?: Maybe<
-          { __typename?: "sub_categories" } & Pick<
-            Sub_Categories,
-            "id" | "name"
-          >
-        >;
-        circle_skills: Array<
-          { __typename?: "circle_skills" } & {
-            skills: { __typename?: "skills" } & Pick<
-              Skills,
-              "id" | "name" | "avatar"
-            >;
-          }
-        >;
-      }
-  >;
-};
+
+export type CircleQuery = (
+  { __typename?: 'query_root' }
+  & { circle?: Maybe<(
+    { __typename?: 'circles' }
+    & Pick<Circles, 'id' | 'avatar' | 'name' | 'mainRole' | 'whatWeWillDo' | 'recruitTitle'>
+    & { owner?: Maybe<(
+      { __typename?: 'users' }
+      & Pick<Users, 'id' | 'name' | 'avatar'>
+    )>, subCategories?: Maybe<(
+      { __typename?: 'sub_categories' }
+      & Pick<Sub_Categories, 'id' | 'name'>
+    )>, circleSkills: Array<(
+      { __typename?: 'circle_skills' }
+      & { skill: (
+        { __typename?: 'skills' }
+        & Pick<Skills, 'id' | 'name' | 'avatar'>
+      ) }
+    )> }
+  )> }
+);
 
 export type CirclesQueryVariables = Exact<{
-  limit: Scalars["Int"];
-  offset: Scalars["Int"];
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
   where?: Maybe<Circles_Bool_Exp>;
 }>;
 
-export type CirclesQuery = { __typename?: "query_root" } & {
-  circles: Array<
-    { __typename?: "circles" } & Pick<
-      Circles,
-      | "id"
-      | "name"
-      | "recruit_title"
-      | "avatar"
-      | "what_we_will_do"
-      | "main_role"
-    >
-  >;
-  circles_aggregate: { __typename?: "circles_aggregate" } & {
-    aggregate?: Maybe<
-      { __typename?: "circles_aggregate_fields" } & Pick<
-        Circles_Aggregate_Fields,
-        "count"
-      >
-    >;
-  };
-};
 
-export type SkillAndSubCategoryQueryVariables = Exact<{ [key: string]: never }>;
+export type CirclesQuery = (
+  { __typename?: 'query_root' }
+  & { circles: Array<(
+    { __typename?: 'circles' }
+    & Pick<Circles, 'id' | 'name' | 'recruitTitle' | 'avatar' | 'whatWeWillDo' | 'mainRole'>
+  )>, circles_aggregate: (
+    { __typename?: 'circles_aggregate' }
+    & { aggregate?: Maybe<(
+      { __typename?: 'circles_aggregate_fields' }
+      & Pick<Circles_Aggregate_Fields, 'count'>
+    )> }
+  ) }
+);
 
-export type SkillAndSubCategoryQuery = { __typename?: "query_root" } & {
-  skills: Array<
-    { __typename?: "skills" } & Pick<Skills, "id" | "avatar" | "name">
-  >;
-  sub_categories: Array<
-    { __typename?: "sub_categories" } & Pick<Sub_Categories, "id" | "name">
-  >;
-};
+export type SkillAndSubCategoryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type SkillAndSubCategoryQuery = (
+  { __typename?: 'query_root' }
+  & { skills: Array<(
+    { __typename?: 'skills' }
+    & Pick<Skills, 'id' | 'avatar' | 'name'>
+  )>, subCategories: Array<(
+    { __typename?: 'sub_categories' }
+    & Pick<Sub_Categories, 'id' | 'name'>
+  )> }
+);
 
 export type UserQueryVariables = Exact<{
-  id: Scalars["String"];
+  id: Scalars['String'];
 }>;
 
-export type UserQuery = { __typename?: "query_root" } & {
-  user?: Maybe<
-    { __typename?: "users" } & Pick<
-      Users,
-      "id" | "avatar" | "name" | "introduction" | "interested_in"
-    > & {
-        user_skills: Array<
-          { __typename?: "user_skills" } & {
-            skills: { __typename?: "skills" } & Pick<
-              Skills,
-              "id" | "avatar" | "name"
-            >;
-          }
-        >;
-        circle_users: Array<
-          { __typename?: "circle_users" } & {
-            circle: { __typename?: "circles" } & Pick<
-              Circles,
-              "id" | "avatar" | "name"
-            >;
-          }
-        >;
-      }
-  >;
-};
+
+export type UserQuery = (
+  { __typename?: 'query_root' }
+  & { user?: Maybe<(
+    { __typename?: 'users' }
+    & Pick<Users, 'id' | 'avatar' | 'name' | 'introduction' | 'interestedIn'>
+    & { userSkills: Array<(
+      { __typename?: 'user_skills' }
+      & { skill: (
+        { __typename?: 'skills' }
+        & Pick<Skills, 'id' | 'avatar' | 'name'>
+      ) }
+    )>, circleUsers: Array<(
+      { __typename?: 'circle_users' }
+      & { circle: (
+        { __typename?: 'circles' }
+        & Pick<Circles, 'id' | 'avatar' | 'name'>
+      ) }
+    )> }
+  )> }
+);
+
 
 export const DeleteCircleSkillDocument = gql`
-  mutation DeleteCircleSkill($circleId: Int!, $skillId: Int!) {
-    delete_circle_skills(
-      where: { circle_id: { _eq: $circleId }, skill_id: { _eq: $skillId } }
-    ) {
-      affected_rows
-    }
+    mutation DeleteCircleSkill($circleId: Int!, $skillId: Int!) {
+  delete_circle_skills(where: {circleId: {_eq: $circleId}, skillId: {_eq: $skillId}}) {
+    affected_rows
   }
-`;
-export type DeleteCircleSkillMutationFn = Apollo.MutationFunction<
-  DeleteCircleSkillMutation,
-  DeleteCircleSkillMutationVariables
->;
+}
+    `;
+export type DeleteCircleSkillMutationFn = Apollo.MutationFunction<DeleteCircleSkillMutation, DeleteCircleSkillMutationVariables>;
 
 /**
  * __useDeleteCircleSkillMutation__
@@ -4535,40 +4665,20 @@ export type DeleteCircleSkillMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteCircleSkillMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    DeleteCircleSkillMutation,
-    DeleteCircleSkillMutationVariables
-  >
-) {
-  return Apollo.useMutation<
-    DeleteCircleSkillMutation,
-    DeleteCircleSkillMutationVariables
-  >(DeleteCircleSkillDocument, baseOptions);
-}
-export type DeleteCircleSkillMutationHookResult = ReturnType<
-  typeof useDeleteCircleSkillMutation
->;
-export type DeleteCircleSkillMutationResult = Apollo.MutationResult<
-  DeleteCircleSkillMutation
->;
-export type DeleteCircleSkillMutationOptions = Apollo.BaseMutationOptions<
-  DeleteCircleSkillMutation,
-  DeleteCircleSkillMutationVariables
->;
+export function useDeleteCircleSkillMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCircleSkillMutation, DeleteCircleSkillMutationVariables>) {
+        return Apollo.useMutation<DeleteCircleSkillMutation, DeleteCircleSkillMutationVariables>(DeleteCircleSkillDocument, baseOptions);
+      }
+export type DeleteCircleSkillMutationHookResult = ReturnType<typeof useDeleteCircleSkillMutation>;
+export type DeleteCircleSkillMutationResult = Apollo.MutationResult<DeleteCircleSkillMutation>;
+export type DeleteCircleSkillMutationOptions = Apollo.BaseMutationOptions<DeleteCircleSkillMutation, DeleteCircleSkillMutationVariables>;
 export const DeleteUserSkillDocument = gql`
-  mutation DeleteUserSkill($userId: String!, $skillId: Int!) {
-    delete_user_skills(
-      where: { user_id: { _eq: $userId }, skill_id: { _eq: $skillId } }
-    ) {
-      affected_rows
-    }
+    mutation DeleteUserSkill($userId: String!, $skillId: Int!) {
+  delete_user_skills(where: {userId: {_eq: $userId}, skillId: {_eq: $skillId}}) {
+    affected_rows
   }
-`;
-export type DeleteUserSkillMutationFn = Apollo.MutationFunction<
-  DeleteUserSkillMutation,
-  DeleteUserSkillMutationVariables
->;
+}
+    `;
+export type DeleteUserSkillMutationFn = Apollo.MutationFunction<DeleteUserSkillMutation, DeleteUserSkillMutationVariables>;
 
 /**
  * __useDeleteUserSkillMutation__
@@ -4588,38 +4698,20 @@ export type DeleteUserSkillMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteUserSkillMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    DeleteUserSkillMutation,
-    DeleteUserSkillMutationVariables
-  >
-) {
-  return Apollo.useMutation<
-    DeleteUserSkillMutation,
-    DeleteUserSkillMutationVariables
-  >(DeleteUserSkillDocument, baseOptions);
-}
-export type DeleteUserSkillMutationHookResult = ReturnType<
-  typeof useDeleteUserSkillMutation
->;
-export type DeleteUserSkillMutationResult = Apollo.MutationResult<
-  DeleteUserSkillMutation
->;
-export type DeleteUserSkillMutationOptions = Apollo.BaseMutationOptions<
-  DeleteUserSkillMutation,
-  DeleteUserSkillMutationVariables
->;
+export function useDeleteUserSkillMutation(baseOptions?: Apollo.MutationHookOptions<DeleteUserSkillMutation, DeleteUserSkillMutationVariables>) {
+        return Apollo.useMutation<DeleteUserSkillMutation, DeleteUserSkillMutationVariables>(DeleteUserSkillDocument, baseOptions);
+      }
+export type DeleteUserSkillMutationHookResult = ReturnType<typeof useDeleteUserSkillMutation>;
+export type DeleteUserSkillMutationResult = Apollo.MutationResult<DeleteUserSkillMutation>;
+export type DeleteUserSkillMutationOptions = Apollo.BaseMutationOptions<DeleteUserSkillMutation, DeleteUserSkillMutationVariables>;
 export const InsertCircleDocument = gql`
-  mutation InsertCircle($objects: [circles_insert_input!]!) {
-    insert_circles(objects: $objects) {
-      affected_rows
-    }
+    mutation InsertCircle($objects: [circles_insert_input!]!) {
+  insert_circles(objects: $objects) {
+    affected_rows
   }
-`;
-export type InsertCircleMutationFn = Apollo.MutationFunction<
-  InsertCircleMutation,
-  InsertCircleMutationVariables
->;
+}
+    `;
+export type InsertCircleMutationFn = Apollo.MutationFunction<InsertCircleMutation, InsertCircleMutationVariables>;
 
 /**
  * __useInsertCircleMutation__
@@ -4638,40 +4730,20 @@ export type InsertCircleMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useInsertCircleMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    InsertCircleMutation,
-    InsertCircleMutationVariables
-  >
-) {
-  return Apollo.useMutation<
-    InsertCircleMutation,
-    InsertCircleMutationVariables
-  >(InsertCircleDocument, baseOptions);
-}
-export type InsertCircleMutationHookResult = ReturnType<
-  typeof useInsertCircleMutation
->;
-export type InsertCircleMutationResult = Apollo.MutationResult<
-  InsertCircleMutation
->;
-export type InsertCircleMutationOptions = Apollo.BaseMutationOptions<
-  InsertCircleMutation,
-  InsertCircleMutationVariables
->;
+export function useInsertCircleMutation(baseOptions?: Apollo.MutationHookOptions<InsertCircleMutation, InsertCircleMutationVariables>) {
+        return Apollo.useMutation<InsertCircleMutation, InsertCircleMutationVariables>(InsertCircleDocument, baseOptions);
+      }
+export type InsertCircleMutationHookResult = ReturnType<typeof useInsertCircleMutation>;
+export type InsertCircleMutationResult = Apollo.MutationResult<InsertCircleMutation>;
+export type InsertCircleMutationOptions = Apollo.BaseMutationOptions<InsertCircleMutation, InsertCircleMutationVariables>;
 export const InsertCircleSkillDocument = gql`
-  mutation InsertCircleSkill($circleId: Int!, $skillId: Int!) {
-    insert_circle_skills(
-      objects: { circle_id: $circleId, skill_id: $skillId }
-    ) {
-      affected_rows
-    }
+    mutation InsertCircleSkill($circleId: Int!, $skillId: Int!) {
+  insert_circle_skills(objects: {circleId: $circleId, skillId: $skillId}) {
+    affected_rows
   }
-`;
-export type InsertCircleSkillMutationFn = Apollo.MutationFunction<
-  InsertCircleSkillMutation,
-  InsertCircleSkillMutationVariables
->;
+}
+    `;
+export type InsertCircleSkillMutationFn = Apollo.MutationFunction<InsertCircleSkillMutation, InsertCircleSkillMutationVariables>;
 
 /**
  * __useInsertCircleSkillMutation__
@@ -4691,40 +4763,20 @@ export type InsertCircleSkillMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useInsertCircleSkillMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    InsertCircleSkillMutation,
-    InsertCircleSkillMutationVariables
-  >
-) {
-  return Apollo.useMutation<
-    InsertCircleSkillMutation,
-    InsertCircleSkillMutationVariables
-  >(InsertCircleSkillDocument, baseOptions);
-}
-export type InsertCircleSkillMutationHookResult = ReturnType<
-  typeof useInsertCircleSkillMutation
->;
-export type InsertCircleSkillMutationResult = Apollo.MutationResult<
-  InsertCircleSkillMutation
->;
-export type InsertCircleSkillMutationOptions = Apollo.BaseMutationOptions<
-  InsertCircleSkillMutation,
-  InsertCircleSkillMutationVariables
->;
+export function useInsertCircleSkillMutation(baseOptions?: Apollo.MutationHookOptions<InsertCircleSkillMutation, InsertCircleSkillMutationVariables>) {
+        return Apollo.useMutation<InsertCircleSkillMutation, InsertCircleSkillMutationVariables>(InsertCircleSkillDocument, baseOptions);
+      }
+export type InsertCircleSkillMutationHookResult = ReturnType<typeof useInsertCircleSkillMutation>;
+export type InsertCircleSkillMutationResult = Apollo.MutationResult<InsertCircleSkillMutation>;
+export type InsertCircleSkillMutationOptions = Apollo.BaseMutationOptions<InsertCircleSkillMutation, InsertCircleSkillMutationVariables>;
 export const InsertUserSkillDocument = gql`
-  mutation InsertUserSkill($userId: String!, $skillId: Int!) {
-    insert_user_skills(
-      objects: { user_id: $userId, skill_id: $skillId, level: 1 }
-    ) {
-      affected_rows
-    }
+    mutation InsertUserSkill($userId: String!, $skillId: Int!) {
+  insert_user_skills(objects: {userId: $userId, skillId: $skillId, level: 1}) {
+    affected_rows
   }
-`;
-export type InsertUserSkillMutationFn = Apollo.MutationFunction<
-  InsertUserSkillMutation,
-  InsertUserSkillMutationVariables
->;
+}
+    `;
+export type InsertUserSkillMutationFn = Apollo.MutationFunction<InsertUserSkillMutation, InsertUserSkillMutationVariables>;
 
 /**
  * __useInsertUserSkillMutation__
@@ -4744,38 +4796,20 @@ export type InsertUserSkillMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useInsertUserSkillMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    InsertUserSkillMutation,
-    InsertUserSkillMutationVariables
-  >
-) {
-  return Apollo.useMutation<
-    InsertUserSkillMutation,
-    InsertUserSkillMutationVariables
-  >(InsertUserSkillDocument, baseOptions);
-}
-export type InsertUserSkillMutationHookResult = ReturnType<
-  typeof useInsertUserSkillMutation
->;
-export type InsertUserSkillMutationResult = Apollo.MutationResult<
-  InsertUserSkillMutation
->;
-export type InsertUserSkillMutationOptions = Apollo.BaseMutationOptions<
-  InsertUserSkillMutation,
-  InsertUserSkillMutationVariables
->;
+export function useInsertUserSkillMutation(baseOptions?: Apollo.MutationHookOptions<InsertUserSkillMutation, InsertUserSkillMutationVariables>) {
+        return Apollo.useMutation<InsertUserSkillMutation, InsertUserSkillMutationVariables>(InsertUserSkillDocument, baseOptions);
+      }
+export type InsertUserSkillMutationHookResult = ReturnType<typeof useInsertUserSkillMutation>;
+export type InsertUserSkillMutationResult = Apollo.MutationResult<InsertUserSkillMutation>;
+export type InsertUserSkillMutationOptions = Apollo.BaseMutationOptions<InsertUserSkillMutation, InsertUserSkillMutationVariables>;
 export const UpdateCirlceDocument = gql`
-  mutation UpdateCirlce($id: Int!, $inputs: circles_set_input) {
-    update_circles(where: { id: { _eq: $id } }, _set: $inputs) {
-      affected_rows
-    }
+    mutation UpdateCirlce($id: Int!, $inputs: circles_set_input) {
+  update_circles(where: {id: {_eq: $id}}, _set: $inputs) {
+    affected_rows
   }
-`;
-export type UpdateCirlceMutationFn = Apollo.MutationFunction<
-  UpdateCirlceMutation,
-  UpdateCirlceMutationVariables
->;
+}
+    `;
+export type UpdateCirlceMutationFn = Apollo.MutationFunction<UpdateCirlceMutation, UpdateCirlceMutationVariables>;
 
 /**
  * __useUpdateCirlceMutation__
@@ -4795,38 +4829,20 @@ export type UpdateCirlceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateCirlceMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UpdateCirlceMutation,
-    UpdateCirlceMutationVariables
-  >
-) {
-  return Apollo.useMutation<
-    UpdateCirlceMutation,
-    UpdateCirlceMutationVariables
-  >(UpdateCirlceDocument, baseOptions);
-}
-export type UpdateCirlceMutationHookResult = ReturnType<
-  typeof useUpdateCirlceMutation
->;
-export type UpdateCirlceMutationResult = Apollo.MutationResult<
-  UpdateCirlceMutation
->;
-export type UpdateCirlceMutationOptions = Apollo.BaseMutationOptions<
-  UpdateCirlceMutation,
-  UpdateCirlceMutationVariables
->;
+export function useUpdateCirlceMutation(baseOptions?: Apollo.MutationHookOptions<UpdateCirlceMutation, UpdateCirlceMutationVariables>) {
+        return Apollo.useMutation<UpdateCirlceMutation, UpdateCirlceMutationVariables>(UpdateCirlceDocument, baseOptions);
+      }
+export type UpdateCirlceMutationHookResult = ReturnType<typeof useUpdateCirlceMutation>;
+export type UpdateCirlceMutationResult = Apollo.MutationResult<UpdateCirlceMutation>;
+export type UpdateCirlceMutationOptions = Apollo.BaseMutationOptions<UpdateCirlceMutation, UpdateCirlceMutationVariables>;
 export const UpdateUserDocument = gql`
-  mutation updateUser($_set: users_set_input, $where: users_bool_exp!) {
-    update_users(where: $where, _set: $_set) {
-      affected_rows
-    }
+    mutation updateUser($_set: users_set_input, $where: users_bool_exp!) {
+  update_users(where: $where, _set: $_set) {
+    affected_rows
   }
-`;
-export type UpdateUserMutationFn = Apollo.MutationFunction<
-  UpdateUserMutation,
-  UpdateUserMutationVariables
->;
+}
+    `;
+export type UpdateUserMutationFn = Apollo.MutationFunction<UpdateUserMutation, UpdateUserMutationVariables>;
 
 /**
  * __useUpdateUserMutation__
@@ -4846,39 +4862,24 @@ export type UpdateUserMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateUserMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UpdateUserMutation,
-    UpdateUserMutationVariables
-  >
-) {
-  return Apollo.useMutation<UpdateUserMutation, UpdateUserMutationVariables>(
-    UpdateUserDocument,
-    baseOptions
-  );
-}
-export type UpdateUserMutationHookResult = ReturnType<
-  typeof useUpdateUserMutation
->;
-export type UpdateUserMutationResult = Apollo.MutationResult<
-  UpdateUserMutation
->;
-export type UpdateUserMutationOptions = Apollo.BaseMutationOptions<
-  UpdateUserMutation,
-  UpdateUserMutationVariables
->;
+export function useUpdateUserMutation(baseOptions?: Apollo.MutationHookOptions<UpdateUserMutation, UpdateUserMutationVariables>) {
+        return Apollo.useMutation<UpdateUserMutation, UpdateUserMutationVariables>(UpdateUserDocument, baseOptions);
+      }
+export type UpdateUserMutationHookResult = ReturnType<typeof useUpdateUserMutation>;
+export type UpdateUserMutationResult = Apollo.MutationResult<UpdateUserMutation>;
+export type UpdateUserMutationOptions = Apollo.BaseMutationOptions<UpdateUserMutation, UpdateUserMutationVariables>;
 export const CategoriesDocument = gql`
-  query Categories {
-    parent_categories {
+    query Categories {
+  parentCategories {
+    id
+    name
+    subCategories {
       id
       name
-      sub_categories {
-        id
-        name
-      }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useCategoriesQuery__
@@ -4895,64 +4896,43 @@ export const CategoriesDocument = gql`
  *   },
  * });
  */
-export function useCategoriesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    CategoriesQuery,
-    CategoriesQueryVariables
-  >
-) {
-  return Apollo.useQuery<CategoriesQuery, CategoriesQueryVariables>(
-    CategoriesDocument,
-    baseOptions
-  );
-}
-export function useCategoriesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    CategoriesQuery,
-    CategoriesQueryVariables
-  >
-) {
-  return Apollo.useLazyQuery<CategoriesQuery, CategoriesQueryVariables>(
-    CategoriesDocument,
-    baseOptions
-  );
-}
+export function useCategoriesQuery(baseOptions?: Apollo.QueryHookOptions<CategoriesQuery, CategoriesQueryVariables>) {
+        return Apollo.useQuery<CategoriesQuery, CategoriesQueryVariables>(CategoriesDocument, baseOptions);
+      }
+export function useCategoriesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CategoriesQuery, CategoriesQueryVariables>) {
+          return Apollo.useLazyQuery<CategoriesQuery, CategoriesQueryVariables>(CategoriesDocument, baseOptions);
+        }
 export type CategoriesQueryHookResult = ReturnType<typeof useCategoriesQuery>;
-export type CategoriesLazyQueryHookResult = ReturnType<
-  typeof useCategoriesLazyQuery
->;
-export type CategoriesQueryResult = Apollo.QueryResult<
-  CategoriesQuery,
-  CategoriesQueryVariables
->;
+export type CategoriesLazyQueryHookResult = ReturnType<typeof useCategoriesLazyQuery>;
+export type CategoriesQueryResult = Apollo.QueryResult<CategoriesQuery, CategoriesQueryVariables>;
 export const CircleDocument = gql`
-  query Circle($id: Int!) {
-    circle: circles_by_pk(id: $id) {
+    query Circle($id: Int!) {
+  circle: circles_by_pk(id: $id) {
+    id
+    avatar
+    name
+    mainRole
+    whatWeWillDo
+    recruitTitle
+    owner {
       id
-      avatar
       name
-      main_role
-      what_we_will_do
-      recruit_title
-      owner: users {
+      avatar
+    }
+    subCategories {
+      id
+      name
+    }
+    circleSkills {
+      skill {
         id
         name
         avatar
       }
-      sub_categories {
-        id
-        name
-      }
-      circle_skills {
-        skills {
-          id
-          name
-          avatar
-        }
-      }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useCircleQuery__
@@ -4970,45 +4950,32 @@ export const CircleDocument = gql`
  *   },
  * });
  */
-export function useCircleQuery(
-  baseOptions?: Apollo.QueryHookOptions<CircleQuery, CircleQueryVariables>
-) {
-  return Apollo.useQuery<CircleQuery, CircleQueryVariables>(
-    CircleDocument,
-    baseOptions
-  );
-}
-export function useCircleLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<CircleQuery, CircleQueryVariables>
-) {
-  return Apollo.useLazyQuery<CircleQuery, CircleQueryVariables>(
-    CircleDocument,
-    baseOptions
-  );
-}
+export function useCircleQuery(baseOptions?: Apollo.QueryHookOptions<CircleQuery, CircleQueryVariables>) {
+        return Apollo.useQuery<CircleQuery, CircleQueryVariables>(CircleDocument, baseOptions);
+      }
+export function useCircleLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CircleQuery, CircleQueryVariables>) {
+          return Apollo.useLazyQuery<CircleQuery, CircleQueryVariables>(CircleDocument, baseOptions);
+        }
 export type CircleQueryHookResult = ReturnType<typeof useCircleQuery>;
 export type CircleLazyQueryHookResult = ReturnType<typeof useCircleLazyQuery>;
-export type CircleQueryResult = Apollo.QueryResult<
-  CircleQuery,
-  CircleQueryVariables
->;
+export type CircleQueryResult = Apollo.QueryResult<CircleQuery, CircleQueryVariables>;
 export const CirclesDocument = gql`
-  query Circles($limit: Int!, $offset: Int!, $where: circles_bool_exp) {
-    circles(limit: $limit, offset: $offset, where: $where) {
-      id
-      name
-      recruit_title
-      avatar
-      what_we_will_do
-      main_role
-    }
-    circles_aggregate(where: $where) {
-      aggregate {
-        count(columns: avatar)
-      }
+    query Circles($limit: Int!, $offset: Int!, $where: circles_bool_exp) {
+  circles(limit: $limit, offset: $offset, where: $where) {
+    id
+    name
+    recruitTitle
+    avatar
+    whatWeWillDo
+    mainRole
+  }
+  circles_aggregate(where: $where) {
+    aggregate {
+      count(columns: avatar)
     }
   }
-`;
+}
+    `;
 
 /**
  * __useCirclesQuery__
@@ -5028,41 +4995,28 @@ export const CirclesDocument = gql`
  *   },
  * });
  */
-export function useCirclesQuery(
-  baseOptions?: Apollo.QueryHookOptions<CirclesQuery, CirclesQueryVariables>
-) {
-  return Apollo.useQuery<CirclesQuery, CirclesQueryVariables>(
-    CirclesDocument,
-    baseOptions
-  );
-}
-export function useCirclesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<CirclesQuery, CirclesQueryVariables>
-) {
-  return Apollo.useLazyQuery<CirclesQuery, CirclesQueryVariables>(
-    CirclesDocument,
-    baseOptions
-  );
-}
+export function useCirclesQuery(baseOptions?: Apollo.QueryHookOptions<CirclesQuery, CirclesQueryVariables>) {
+        return Apollo.useQuery<CirclesQuery, CirclesQueryVariables>(CirclesDocument, baseOptions);
+      }
+export function useCirclesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CirclesQuery, CirclesQueryVariables>) {
+          return Apollo.useLazyQuery<CirclesQuery, CirclesQueryVariables>(CirclesDocument, baseOptions);
+        }
 export type CirclesQueryHookResult = ReturnType<typeof useCirclesQuery>;
 export type CirclesLazyQueryHookResult = ReturnType<typeof useCirclesLazyQuery>;
-export type CirclesQueryResult = Apollo.QueryResult<
-  CirclesQuery,
-  CirclesQueryVariables
->;
+export type CirclesQueryResult = Apollo.QueryResult<CirclesQuery, CirclesQueryVariables>;
 export const SkillAndSubCategoryDocument = gql`
-  query SkillAndSubCategory {
-    skills {
-      id
-      avatar
-      name
-    }
-    sub_categories {
-      id
-      name
-    }
+    query SkillAndSubCategory {
+  skills {
+    id
+    avatar
+    name
   }
-`;
+  subCategories {
+    id
+    name
+  }
+}
+    `;
 
 /**
  * __useSkillAndSubCategoryQuery__
@@ -5079,63 +5033,40 @@ export const SkillAndSubCategoryDocument = gql`
  *   },
  * });
  */
-export function useSkillAndSubCategoryQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    SkillAndSubCategoryQuery,
-    SkillAndSubCategoryQueryVariables
-  >
-) {
-  return Apollo.useQuery<
-    SkillAndSubCategoryQuery,
-    SkillAndSubCategoryQueryVariables
-  >(SkillAndSubCategoryDocument, baseOptions);
-}
-export function useSkillAndSubCategoryLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    SkillAndSubCategoryQuery,
-    SkillAndSubCategoryQueryVariables
-  >
-) {
-  return Apollo.useLazyQuery<
-    SkillAndSubCategoryQuery,
-    SkillAndSubCategoryQueryVariables
-  >(SkillAndSubCategoryDocument, baseOptions);
-}
-export type SkillAndSubCategoryQueryHookResult = ReturnType<
-  typeof useSkillAndSubCategoryQuery
->;
-export type SkillAndSubCategoryLazyQueryHookResult = ReturnType<
-  typeof useSkillAndSubCategoryLazyQuery
->;
-export type SkillAndSubCategoryQueryResult = Apollo.QueryResult<
-  SkillAndSubCategoryQuery,
-  SkillAndSubCategoryQueryVariables
->;
-export const UserDocument = gql`
-  query User($id: String!) {
-    user: users_by_pk(id: $id) {
-      id
-      avatar
-      name
-      introduction
-      interested_in
-      user_skills {
-        skills {
-          id
-          avatar
-          name
-        }
+export function useSkillAndSubCategoryQuery(baseOptions?: Apollo.QueryHookOptions<SkillAndSubCategoryQuery, SkillAndSubCategoryQueryVariables>) {
+        return Apollo.useQuery<SkillAndSubCategoryQuery, SkillAndSubCategoryQueryVariables>(SkillAndSubCategoryDocument, baseOptions);
       }
-      circle_users {
-        circle {
-          id
-          avatar
-          name
+export function useSkillAndSubCategoryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SkillAndSubCategoryQuery, SkillAndSubCategoryQueryVariables>) {
+          return Apollo.useLazyQuery<SkillAndSubCategoryQuery, SkillAndSubCategoryQueryVariables>(SkillAndSubCategoryDocument, baseOptions);
         }
+export type SkillAndSubCategoryQueryHookResult = ReturnType<typeof useSkillAndSubCategoryQuery>;
+export type SkillAndSubCategoryLazyQueryHookResult = ReturnType<typeof useSkillAndSubCategoryLazyQuery>;
+export type SkillAndSubCategoryQueryResult = Apollo.QueryResult<SkillAndSubCategoryQuery, SkillAndSubCategoryQueryVariables>;
+export const UserDocument = gql`
+    query User($id: String!) {
+  user: users_by_pk(id: $id) {
+    id
+    avatar
+    name
+    introduction
+    interestedIn
+    userSkills {
+      skill {
+        id
+        avatar
+        name
+      }
+    }
+    circleUsers {
+      circle {
+        id
+        avatar
+        name
       }
     }
   }
-`;
+}
+    `;
 
 /**
  * __useUserQuery__
@@ -5153,22 +5084,12 @@ export const UserDocument = gql`
  *   },
  * });
  */
-export function useUserQuery(
-  baseOptions?: Apollo.QueryHookOptions<UserQuery, UserQueryVariables>
-) {
-  return Apollo.useQuery<UserQuery, UserQueryVariables>(
-    UserDocument,
-    baseOptions
-  );
-}
-export function useUserLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<UserQuery, UserQueryVariables>
-) {
-  return Apollo.useLazyQuery<UserQuery, UserQueryVariables>(
-    UserDocument,
-    baseOptions
-  );
-}
+export function useUserQuery(baseOptions?: Apollo.QueryHookOptions<UserQuery, UserQueryVariables>) {
+        return Apollo.useQuery<UserQuery, UserQueryVariables>(UserDocument, baseOptions);
+      }
+export function useUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserQuery, UserQueryVariables>) {
+          return Apollo.useLazyQuery<UserQuery, UserQueryVariables>(UserDocument, baseOptions);
+        }
 export type UserQueryHookResult = ReturnType<typeof useUserQuery>;
 export type UserLazyQueryHookResult = ReturnType<typeof useUserLazyQuery>;
 export type UserQueryResult = Apollo.QueryResult<UserQuery, UserQueryVariables>;

--- a/packages/web/src/generated/graphql.tsx
+++ b/packages/web/src/generated/graphql.tsx
@@ -674,7 +674,7 @@ export type Circles = {
   ownerId?: Maybe<Scalars['String']>;
   recruitTitle?: Maybe<Scalars['String']>;
   /** An object relationship */
-  subCategories?: Maybe<Sub_Categories>;
+  subCategory?: Maybe<Sub_Categories>;
   subCategoryId?: Maybe<Scalars['Int']>;
   whatWeWillDo?: Maybe<Scalars['String']>;
 };
@@ -820,7 +820,7 @@ export type Circles_Bool_Exp = {
   owner?: Maybe<Users_Bool_Exp>;
   ownerId?: Maybe<String_Comparison_Exp>;
   recruitTitle?: Maybe<String_Comparison_Exp>;
-  subCategories?: Maybe<Sub_Categories_Bool_Exp>;
+  subCategory?: Maybe<Sub_Categories_Bool_Exp>;
   subCategoryId?: Maybe<Int_Comparison_Exp>;
   whatWeWillDo?: Maybe<String_Comparison_Exp>;
 };
@@ -851,7 +851,7 @@ export type Circles_Insert_Input = {
   owner?: Maybe<Users_Obj_Rel_Insert_Input>;
   ownerId?: Maybe<Scalars['String']>;
   recruitTitle?: Maybe<Scalars['String']>;
-  subCategories?: Maybe<Sub_Categories_Obj_Rel_Insert_Input>;
+  subCategory?: Maybe<Sub_Categories_Obj_Rel_Insert_Input>;
   subCategoryId?: Maybe<Scalars['Int']>;
   whatWeWillDo?: Maybe<Scalars['String']>;
 };
@@ -946,7 +946,7 @@ export type Circles_Order_By = {
   owner?: Maybe<Users_Order_By>;
   ownerId?: Maybe<Order_By>;
   recruitTitle?: Maybe<Order_By>;
-  subCategories?: Maybe<Sub_Categories_Order_By>;
+  subCategory?: Maybe<Sub_Categories_Order_By>;
   subCategoryId?: Maybe<Order_By>;
   whatWeWillDo?: Maybe<Order_By>;
 };
@@ -4563,7 +4563,7 @@ export type CircleQuery = (
     & { owner?: Maybe<(
       { __typename?: 'users' }
       & Pick<Users, 'id' | 'name' | 'avatar'>
-    )>, subCategories?: Maybe<(
+    )>, subCategory?: Maybe<(
       { __typename?: 'sub_categories' }
       & Pick<Sub_Categories, 'id' | 'name'>
     )>, circleSkills: Array<(
@@ -4919,7 +4919,7 @@ export const CircleDocument = gql`
       name
       avatar
     }
-    subCategories {
+    subCategory {
       id
       name
     }

--- a/packages/web/src/graphql/mutations/DeleteCircleSkill.graphql
+++ b/packages/web/src/graphql/mutations/DeleteCircleSkill.graphql
@@ -1,6 +1,6 @@
 mutation DeleteCircleSkill($circleId: Int!, $skillId: Int!) {
   delete_circle_skills(
-    where: { circle_id: { _eq: $circleId }, skill_id: { _eq: $skillId } }
+    where: { circleId: { _eq: $circleId }, skillId: { _eq: $skillId } }
   ) {
     affected_rows
   }

--- a/packages/web/src/graphql/mutations/DeleteUserSkill.graphql
+++ b/packages/web/src/graphql/mutations/DeleteUserSkill.graphql
@@ -1,6 +1,6 @@
 mutation DeleteUserSkill($userId: String!, $skillId: Int!) {
   delete_user_skills(
-    where: { user_id: { _eq: $userId }, skill_id: { _eq: $skillId } }
+    where: { userId: { _eq: $userId }, skillId: { _eq: $skillId } }
   ) {
     affected_rows
   }

--- a/packages/web/src/graphql/mutations/InsertCircleSkill.graphql
+++ b/packages/web/src/graphql/mutations/InsertCircleSkill.graphql
@@ -1,5 +1,5 @@
 mutation InsertCircleSkill($circleId: Int!, $skillId: Int!) {
-  insert_circle_skills(objects: { circle_id: $circleId, skill_id: $skillId }) {
+  insert_circle_skills(objects: { circleId: $circleId, skillId: $skillId }) {
     affected_rows
   }
 }

--- a/packages/web/src/graphql/mutations/InsertUserSkill.graphql
+++ b/packages/web/src/graphql/mutations/InsertUserSkill.graphql
@@ -1,6 +1,6 @@
 mutation InsertUserSkill($userId: String!, $skillId: Int!) {
   insert_user_skills(
-    objects: { user_id: $userId, skill_id: $skillId, level: 1 }
+    objects: { userId: $userId, skillId: $skillId, level: 1 }
   ) {
     affected_rows
   }

--- a/packages/web/src/graphql/queries/Categories.graphql
+++ b/packages/web/src/graphql/queries/Categories.graphql
@@ -1,8 +1,8 @@
 query Categories {
-  parent_categories {
+  parentCategories {
     id
     name
-    sub_categories {
+    subCategories {
       id
       name
     }

--- a/packages/web/src/graphql/queries/Circle.graphql
+++ b/packages/web/src/graphql/queries/Circle.graphql
@@ -11,7 +11,7 @@ query Circle($id: Int!) {
       name
       avatar
     }
-    subCategories {
+    subCategory {
       id
       name
     }

--- a/packages/web/src/graphql/queries/Circle.graphql
+++ b/packages/web/src/graphql/queries/Circle.graphql
@@ -3,20 +3,20 @@ query Circle($id: Int!) {
     id
     avatar
     name
-    main_role
-    what_we_will_do
-    recruit_title
-    owner: users {
+    mainRole
+    whatWeWillDo
+    recruitTitle
+    owner {
       id
       name
       avatar
     }
-    sub_categories {
+    subCategories {
       id
       name
     }
-    circle_skills {
-      skills {
+    circleSkills {
+      skill {
         id
         name
         avatar

--- a/packages/web/src/graphql/queries/Circles.graphql
+++ b/packages/web/src/graphql/queries/Circles.graphql
@@ -2,10 +2,10 @@ query Circles($limit: Int!, $offset: Int!, $where: circles_bool_exp) {
   circles(limit: $limit, offset: $offset, where: $where) {
     id
     name
-    recruit_title
+    recruitTitle
     avatar
-    what_we_will_do
-    main_role
+    whatWeWillDo
+    mainRole
   }
   circles_aggregate(where: $where) {
     aggregate {

--- a/packages/web/src/graphql/queries/SkillAndSubCategory.graphql
+++ b/packages/web/src/graphql/queries/SkillAndSubCategory.graphql
@@ -4,7 +4,7 @@ query SkillAndSubCategory {
     avatar
     name
   }
-  sub_categories {
+  subCategories {
     id
     name
   }

--- a/packages/web/src/graphql/queries/User.graphql
+++ b/packages/web/src/graphql/queries/User.graphql
@@ -4,15 +4,15 @@ query User($id: String!) {
     avatar
     name
     introduction
-    interested_in
-    user_skills {
-      skills {
+    interestedIn
+    userSkills {
+      skill {
         id
         avatar
         name
       }
     }
-    circle_users {
+    circleUsers {
       circle {
         id
         avatar


### PR DESCRIPTION
## 参考
https://hasura.io/docs/1.0/graphql/core/schema/custom-field-names.html


## やったこと
- カラムがスネークケースになっているところはGraphQL field nameを使ってキャメルケースに
![image](https://user-images.githubusercontent.com/54174518/100453491-5755cf80-30fe-11eb-953c-91d18b32b35b.png)

- Relationship自体はキャメルケースに変更
![image](https://user-images.githubusercontent.com/54174518/100453460-486f1d00-30fe-11eb-81f8-e1b9fcc7b8df.png)

- Relationshipで単数であるべきところが複数になっている箇所が何箇所かあったので修正
![image](https://user-images.githubusercontent.com/54174518/100453402-30979900-30fe-11eb-902d-f493c0554168.png)



## TODO
insert_usersとかもスネークケース気持ち悪いけど，全部変換するのめんどくさいです。

![image](https://user-images.githubusercontent.com/54174518/100453282-12319d80-30fe-11eb-8b53-a1a7779bffe3.png)

